### PR TITLE
Also skip HTTPOption in Kind (and thus Actions)

### DIFF
--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -35,6 +35,7 @@ export "GATEWAY_NAMESPACE_OVERRIDE=${KOURIER_GATEWAY_NAMESPACE}"
 echo ">> Running conformance tests"
 go test -count=1 -short -timeout=20m -tags=e2e ./test/conformance/... ./test/e2e/... \
   --enable-alpha --enable-beta \
+  --skip-tests="httpoption" \
   --ingressendpoint="${IPS[0]}" \
   --ingressClass=kourier.ingress.networking.knative.dev \
   --cluster-suffix="$CLUSTER_SUFFIX"


### PR DESCRIPTION
As per title. Oversight from https://github.com/knative-sandbox/net-kourier/pull/615