### PR TITLE
Support for configuring envoy connection parameters in ingress, which istio currently supports.

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,3 +1,3 @@
-## Knative Community Code of Conduct
+go test -v -run## Knative Community Code of Conduct
 
 The [Knative Community Code of Conduct](https://github.com/knative/community/blob/main/CODE-OF-CONDUCT.md) is defined in the [Knative community repository](https://github.com/knative/community).

--- a/pkg/envoy/api/cluster_test.go
+++ b/pkg/envoy/api/cluster_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package envoy
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -35,13 +36,25 @@ func TestNewCluster(t *testing.T) {
 	endpoints := []*endpoint.LbEndpoint{endpoint1, endpoint2}
 
 	// With HTTP2
-	c := NewCluster(name, connectTimeout, endpoints, true, nil, v3Cluster.Cluster_STATIC)
+	c := NewCluster(name, ClusterConnectionOpts{
+		MaxConnections:     math.MaxUint32,
+		MaxRequests:        math.MaxUint32,
+		MaxPendingRequests: math.MaxUint32,
+		MaxRetries:         10,
+		ConnectTimeout:     5 * time.Second,
+	}, endpoints, true, nil, v3Cluster.Cluster_STATIC)
 	assert.Equal(t, c.GetConnectTimeout().Seconds, int64(connectTimeout.Seconds()))
 	assert.Assert(t, c.TypedExtensionProtocolOptions["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"] != nil)
 	assert.Equal(t, c.GetName(), name)
 	assert.DeepEqual(t, c.LoadAssignment.Endpoints[0].LbEndpoints, endpoints, protocmp.Transform())
 
 	// Without HTTP2
-	c = NewCluster(name, connectTimeout, endpoints, false, nil, v3Cluster.Cluster_STATIC)
+	c = NewCluster(name, ClusterConnectionOpts{
+		MaxConnections:     math.MaxUint32,
+		MaxRequests:        math.MaxUint32,
+		MaxPendingRequests: math.MaxUint32,
+		MaxRetries:         10,
+		ConnectTimeout:     5 * time.Second,
+	}, endpoints, false, nil, v3Cluster.Cluster_STATIC)
 	assert.Assert(t, c.TypedExtensionProtocolOptions["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"] == nil)
 }

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -122,40 +122,30 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 	// The custom timeout period is matched
 	// This value is set to annotations in the Ingress resource
 	if ct, ok := ingress.Annotations[envoyClusterConnectTimeout]; ok {
-		if v, err := strconv.Atoi(ct); err == nil {
-			if v > 0 && v < math.MaxInt {
-				connectionOpts.ConnectTimeout = time.Duration(v) * time.Second
-			}
+		if v, err := strconv.ParseUint(ct, 10, 32); err == nil {
+			connectionOpts.ConnectTimeout = time.Duration(v) * time.Second
 		}
 	}
 
 	// Set connection default values
 	if mc, ok := ingress.Annotations[envoyClusterMaxConnections]; ok {
-		if v, err := strconv.Atoi(mc); err == nil {
-			if v > 0 && v < math.MaxUint32 {
-				connectionOpts.MaxConnections = uint32(v)
-			}
+		if v, err := strconv.ParseUint(mc, 10, 32); err == nil {
+			connectionOpts.MaxConnections = uint32(v)
 		}
 	}
 	if mpr, ok := ingress.Annotations[envoyClusterMaxPendingRequests]; ok {
-		if v, err := strconv.Atoi(mpr); err == nil {
-			if v > 0 && v < math.MaxUint32 {
-				connectionOpts.MaxPendingRequests = uint32(v)
-			}
+		if v, err := strconv.ParseUint(mpr, 10, 32); err == nil {
+			connectionOpts.MaxPendingRequests = uint32(v)
 		}
 	}
 	if mr, ok := ingress.Annotations[envoyClusterMaxRequests]; ok {
-		if v, err := strconv.Atoi(mr); err == nil {
-			if v > 0 && v < math.MaxUint32 {
-				connectionOpts.MaxRequests = uint32(v)
-			}
+		if v, err := strconv.ParseUint(mr, 10, 32); err == nil {
+			connectionOpts.MaxRequests = uint32(v)
 		}
 	}
 	if mrt, ok := ingress.Annotations[envoyClusterMaxRetries]; ok {
-		if v, err := strconv.Atoi(mrt); err == nil {
-			if v > 0 && v < math.MaxUint32 {
-				connectionOpts.MaxRetries = uint32(v)
-			}
+		if v, err := strconv.ParseUint(mrt, 10, 32); err == nil {
+			connectionOpts.MaxRetries = uint32(v)
 		}
 	}
 

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -41,6 +41,7 @@ import (
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	netconfig "knative.dev/networking/pkg/config"
 	pkgtest "knative.dev/pkg/reconciler/testing"
+	"math"
 	"testing"
 	"time"
 )
@@ -92,10 +93,10 @@ func TestIngressTranslator(t *testing.T) {
 					envoy.NewCluster(
 						"servicens/servicename",
 						envoy.ClusterConnectionOpts{
-							MaxConnections:     defaultMaxConnections,
-							MaxRequests:        defaultMaxConnections,
-							MaxPendingRequests: defaultMaxConnections,
-							MaxRetries:         defaultRetryCount,
+							MaxConnections:     math.MaxUint32,
+							MaxRequests:        math.MaxUint32,
+							MaxPendingRequests: math.MaxUint32,
+							MaxRetries:         10,
 							ConnectTimeout:     5 * time.Second,
 						},
 						lbEndpoints,
@@ -165,10 +166,10 @@ func TestIngressTranslator(t *testing.T) {
 					envoy.NewCluster(
 						"servicens/servicename",
 						envoy.ClusterConnectionOpts{
-							MaxConnections:     defaultMaxConnections,
-							MaxRequests:        defaultMaxConnections,
-							MaxPendingRequests: defaultMaxConnections,
-							MaxRetries:         defaultRetryCount,
+							MaxConnections:     math.MaxUint32,
+							MaxRequests:        math.MaxUint32,
+							MaxPendingRequests: math.MaxUint32,
+							MaxRetries:         10,
 							ConnectTimeout:     5 * time.Second,
 						},
 						lbEndpoints,
@@ -255,10 +256,10 @@ func TestIngressTranslator(t *testing.T) {
 					envoy.NewCluster(
 						"servicens/servicename",
 						envoy.ClusterConnectionOpts{
-							MaxConnections:     defaultMaxConnections,
-							MaxRequests:        defaultMaxConnections,
-							MaxPendingRequests: defaultMaxConnections,
-							MaxRetries:         defaultRetryCount,
+							MaxConnections:     math.MaxUint32,
+							MaxRequests:        math.MaxUint32,
+							MaxPendingRequests: math.MaxUint32,
+							MaxRetries:         10,
 							ConnectTimeout:     5 * time.Second,
 						},
 						lbEndpoints,
@@ -331,10 +332,10 @@ func TestIngressTranslator(t *testing.T) {
 					envoy.NewCluster(
 						"servicens/servicename",
 						envoy.ClusterConnectionOpts{
-							MaxConnections:     defaultMaxConnections,
-							MaxRequests:        defaultMaxConnections,
-							MaxPendingRequests: defaultMaxConnections,
-							MaxRetries:         defaultRetryCount,
+							MaxConnections:     math.MaxUint32,
+							MaxRequests:        math.MaxUint32,
+							MaxPendingRequests: math.MaxUint32,
+							MaxRetries:         10,
 							ConnectTimeout:     5 * time.Second,
 						},
 						lbEndpoints,
@@ -415,10 +416,10 @@ func TestIngressTranslator(t *testing.T) {
 					envoy.NewCluster(
 						"servicens/servicename",
 						envoy.ClusterConnectionOpts{
-							MaxConnections:     defaultMaxConnections,
-							MaxRequests:        defaultMaxConnections,
-							MaxPendingRequests: defaultMaxConnections,
-							MaxRetries:         defaultRetryCount,
+							MaxConnections:     math.MaxUint32,
+							MaxRequests:        math.MaxUint32,
+							MaxPendingRequests: math.MaxUint32,
+							MaxRetries:         10,
 							ConnectTimeout:     5 * time.Second,
 						},
 						lbEndpoints,
@@ -429,10 +430,10 @@ func TestIngressTranslator(t *testing.T) {
 					envoy.NewCluster(
 						"servicens2/servicename2",
 						envoy.ClusterConnectionOpts{
-							MaxConnections:     defaultMaxConnections,
-							MaxRequests:        defaultMaxConnections,
-							MaxPendingRequests: defaultMaxConnections,
-							MaxRetries:         defaultRetryCount,
+							MaxConnections:     math.MaxUint32,
+							MaxRequests:        math.MaxUint32,
+							MaxPendingRequests: math.MaxUint32,
+							MaxRetries:         10,
 							ConnectTimeout:     5 * time.Second,
 						},
 						lbEndpoints,
@@ -443,10 +444,10 @@ func TestIngressTranslator(t *testing.T) {
 					envoy.NewCluster(
 						"servicens3/servicename3",
 						envoy.ClusterConnectionOpts{
-							MaxConnections:     defaultMaxConnections,
-							MaxRequests:        defaultMaxConnections,
-							MaxPendingRequests: defaultMaxConnections,
-							MaxRetries:         defaultRetryCount,
+							MaxConnections:     math.MaxUint32,
+							MaxRequests:        math.MaxUint32,
+							MaxPendingRequests: math.MaxUint32,
+							MaxRetries:         10,
 							ConnectTimeout:     5 * time.Second,
 						},
 						[]*endpoint.LbEndpoint{envoy.NewLBEndpoint("example.com", 80)},
@@ -503,10 +504,10 @@ func TestIngressTranslator(t *testing.T) {
 					envoy.NewCluster(
 						"servicens/servicename",
 						envoy.ClusterConnectionOpts{
-							MaxConnections:     defaultMaxConnections,
-							MaxRequests:        defaultMaxConnections,
-							MaxPendingRequests: defaultMaxConnections,
-							MaxRetries:         defaultRetryCount,
+							MaxConnections:     math.MaxUint32,
+							MaxRequests:        math.MaxUint32,
+							MaxPendingRequests: math.MaxUint32,
+							MaxRetries:         10,
 							ConnectTimeout:     5 * time.Second,
 						},
 						lbEndpoints,
@@ -563,10 +564,10 @@ func TestIngressTranslator(t *testing.T) {
 					envoy.NewCluster(
 						"servicens/servicename",
 						envoy.ClusterConnectionOpts{
-							MaxConnections:     defaultMaxConnections,
-							MaxRequests:        defaultMaxConnections,
-							MaxPendingRequests: defaultMaxConnections,
-							MaxRetries:         defaultRetryCount,
+							MaxConnections:     math.MaxUint32,
+							MaxRequests:        math.MaxUint32,
+							MaxPendingRequests: math.MaxUint32,
+							MaxRetries:         10,
 							ConnectTimeout:     5 * time.Second,
 						},
 						[]*endpoint.LbEndpoint{envoy.NewLBEndpoint("example.com", 80)},
@@ -624,10 +625,10 @@ func TestIngressTranslator(t *testing.T) {
 					envoy.NewCluster(
 						"servicens/servicename",
 						envoy.ClusterConnectionOpts{
-							MaxConnections:     defaultMaxConnections,
-							MaxRequests:        defaultMaxConnections,
-							MaxPendingRequests: defaultMaxConnections,
-							MaxRetries:         defaultRetryCount,
+							MaxConnections:     math.MaxUint32,
+							MaxRequests:        math.MaxUint32,
+							MaxPendingRequests: math.MaxUint32,
+							MaxRetries:         10,
 							ConnectTimeout:     5 * time.Second,
 						},
 						[]*endpoint.LbEndpoint{envoy.NewLBEndpoint("example.com", 80)},
@@ -765,10 +766,10 @@ func TestIngressTranslatorWithHTTPOptionDisabled(t *testing.T) {
 					envoy.NewCluster(
 						"servicens/servicename",
 						envoy.ClusterConnectionOpts{
-							MaxConnections:     defaultMaxConnections,
-							MaxRequests:        defaultMaxConnections,
-							MaxPendingRequests: defaultMaxConnections,
-							MaxRetries:         defaultRetryCount,
+							MaxConnections:     math.MaxUint32,
+							MaxRequests:        math.MaxUint32,
+							MaxPendingRequests: math.MaxUint32,
+							MaxRetries:         10,
 							ConnectTimeout:     5 * time.Second,
 						},
 						lbEndpoints,
@@ -841,10 +842,10 @@ func TestIngressTranslatorWithHTTPOptionDisabled(t *testing.T) {
 					envoy.NewCluster(
 						"servicens/servicename",
 						envoy.ClusterConnectionOpts{
-							MaxConnections:     defaultMaxConnections,
-							MaxRequests:        defaultMaxConnections,
-							MaxPendingRequests: defaultMaxConnections,
-							MaxRetries:         defaultRetryCount,
+							MaxConnections:     math.MaxUint32,
+							MaxRequests:        math.MaxUint32,
+							MaxPendingRequests: math.MaxUint32,
+							MaxRetries:         10,
 							ConnectTimeout:     5 * time.Second,
 						},
 						lbEndpoints,
@@ -940,10 +941,10 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 					envoy.NewCluster(
 						"servicens/servicename",
 						envoy.ClusterConnectionOpts{
-							MaxConnections:     defaultMaxConnections,
-							MaxRequests:        defaultMaxConnections,
-							MaxPendingRequests: defaultMaxConnections,
-							MaxRetries:         defaultRetryCount,
+							MaxConnections:     math.MaxUint32,
+							MaxRequests:        math.MaxUint32,
+							MaxPendingRequests: math.MaxUint32,
+							MaxRetries:         10,
 							ConnectTimeout:     5 * time.Second,
 						},
 						lbEndpoints,
@@ -1009,10 +1010,10 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 					envoy.NewCluster(
 						"servicens/servicename",
 						envoy.ClusterConnectionOpts{
-							MaxConnections:     defaultMaxConnections,
-							MaxRequests:        defaultMaxConnections,
-							MaxPendingRequests: defaultMaxConnections,
-							MaxRetries:         defaultRetryCount,
+							MaxConnections:     math.MaxUint32,
+							MaxRequests:        math.MaxUint32,
+							MaxPendingRequests: math.MaxUint32,
+							MaxRetries:         10,
 							ConnectTimeout:     5 * time.Second,
 						},
 						lbEndpoints,
@@ -1084,10 +1085,10 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 					envoy.NewCluster(
 						"servicens/servicename",
 						envoy.ClusterConnectionOpts{
-							MaxConnections:     defaultMaxConnections,
-							MaxRequests:        defaultMaxConnections,
-							MaxPendingRequests: defaultMaxConnections,
-							MaxRetries:         defaultRetryCount,
+							MaxConnections:     math.MaxUint32,
+							MaxRequests:        math.MaxUint32,
+							MaxPendingRequests: math.MaxUint32,
+							MaxRetries:         10,
 							ConnectTimeout:     5 * time.Second,
 						},
 						lbHTTPSEndpoints,
@@ -1159,10 +1160,10 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 					envoy.NewCluster(
 						"servicens/servicename",
 						envoy.ClusterConnectionOpts{
-							MaxConnections:     defaultMaxConnections,
-							MaxRequests:        defaultMaxConnections,
-							MaxPendingRequests: defaultMaxConnections,
-							MaxRetries:         defaultRetryCount,
+							MaxConnections:     math.MaxUint32,
+							MaxRequests:        math.MaxUint32,
+							MaxPendingRequests: math.MaxUint32,
+							MaxRetries:         10,
 							ConnectTimeout:     5 * time.Second,
 						},
 						lbHTTPSEndpoints,
@@ -1265,10 +1266,10 @@ func TestIngressTranslatorHTTP01Challenge(t *testing.T) {
 					envoy.NewCluster(
 						"simplens/cm-acme-http-solver",
 						envoy.ClusterConnectionOpts{
-							MaxConnections:     defaultMaxConnections,
-							MaxRequests:        defaultMaxConnections,
-							MaxPendingRequests: defaultMaxConnections,
-							MaxRetries:         defaultRetryCount,
+							MaxConnections:     math.MaxUint32,
+							MaxRequests:        math.MaxUint32,
+							MaxPendingRequests: math.MaxUint32,
+							MaxRetries:         10,
 							ConnectTimeout:     5 * time.Second,
 						},
 						lbEndpointHTTP01Challenge,
@@ -1371,10 +1372,10 @@ func TestIngressTranslatorDomainMappingDisableHTTP2(t *testing.T) {
 					envoy.NewCluster(
 						"servicens/servicename",
 						envoy.ClusterConnectionOpts{
-							MaxConnections:     defaultMaxConnections,
-							MaxRequests:        defaultMaxConnections,
-							MaxPendingRequests: defaultMaxConnections,
-							MaxRetries:         defaultRetryCount,
+							MaxConnections:     math.MaxUint32,
+							MaxRequests:        math.MaxUint32,
+							MaxPendingRequests: math.MaxUint32,
+							MaxRetries:         10,
 							ConnectTimeout:     5 * time.Second,
 						},
 						[]*endpoint.LbEndpoint{

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -18,9 +18,6 @@ package generator
 
 import (
 	"context"
-	"testing"
-	"time"
-
 	v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -44,6 +41,8 @@ import (
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	netconfig "knative.dev/networking/pkg/config"
 	pkgtest "knative.dev/pkg/reconciler/testing"
+	"testing"
+	"time"
 )
 
 func TestIngressTranslator(t *testing.T) {
@@ -92,7 +91,13 @@ func TestIngressTranslator(t *testing.T) {
 				clusters: []*v3.Cluster{
 					envoy.NewCluster(
 						"servicens/servicename",
-						5*time.Second,
+						envoy.ClusterConnectionOpts{
+							MaxConnections:     defaultMaxConnections,
+							MaxRequests:        defaultMaxConnections,
+							MaxPendingRequests: defaultMaxConnections,
+							MaxRetries:         defaultRetryCount,
+							ConnectTimeout:     5 * time.Second,
+						},
 						lbEndpoints,
 						false,
 						nil,
@@ -159,7 +164,13 @@ func TestIngressTranslator(t *testing.T) {
 				clusters: []*v3.Cluster{
 					envoy.NewCluster(
 						"servicens/servicename",
-						5*time.Second,
+						envoy.ClusterConnectionOpts{
+							MaxConnections:     defaultMaxConnections,
+							MaxRequests:        defaultMaxConnections,
+							MaxPendingRequests: defaultMaxConnections,
+							MaxRetries:         defaultRetryCount,
+							ConnectTimeout:     5 * time.Second,
+						},
 						lbEndpoints,
 						false,
 						nil,
@@ -243,7 +254,13 @@ func TestIngressTranslator(t *testing.T) {
 				clusters: []*v3.Cluster{
 					envoy.NewCluster(
 						"servicens/servicename",
-						5*time.Second,
+						envoy.ClusterConnectionOpts{
+							MaxConnections:     defaultMaxConnections,
+							MaxRequests:        defaultMaxConnections,
+							MaxPendingRequests: defaultMaxConnections,
+							MaxRetries:         defaultRetryCount,
+							ConnectTimeout:     5 * time.Second,
+						},
 						lbEndpoints,
 						false,
 						nil,
@@ -313,7 +330,13 @@ func TestIngressTranslator(t *testing.T) {
 				clusters: []*v3.Cluster{
 					envoy.NewCluster(
 						"servicens/servicename",
-						5*time.Second,
+						envoy.ClusterConnectionOpts{
+							MaxConnections:     defaultMaxConnections,
+							MaxRequests:        defaultMaxConnections,
+							MaxPendingRequests: defaultMaxConnections,
+							MaxRetries:         defaultRetryCount,
+							ConnectTimeout:     5 * time.Second,
+						},
 						lbEndpoints,
 						false,
 						nil,
@@ -391,7 +414,13 @@ func TestIngressTranslator(t *testing.T) {
 				clusters: []*v3.Cluster{
 					envoy.NewCluster(
 						"servicens/servicename",
-						5*time.Second,
+						envoy.ClusterConnectionOpts{
+							MaxConnections:     defaultMaxConnections,
+							MaxRequests:        defaultMaxConnections,
+							MaxPendingRequests: defaultMaxConnections,
+							MaxRetries:         defaultRetryCount,
+							ConnectTimeout:     5 * time.Second,
+						},
 						lbEndpoints,
 						false,
 						nil,
@@ -399,7 +428,13 @@ func TestIngressTranslator(t *testing.T) {
 					),
 					envoy.NewCluster(
 						"servicens2/servicename2",
-						5*time.Second,
+						envoy.ClusterConnectionOpts{
+							MaxConnections:     defaultMaxConnections,
+							MaxRequests:        defaultMaxConnections,
+							MaxPendingRequests: defaultMaxConnections,
+							MaxRetries:         defaultRetryCount,
+							ConnectTimeout:     5 * time.Second,
+						},
 						lbEndpoints,
 						false,
 						nil,
@@ -407,7 +442,13 @@ func TestIngressTranslator(t *testing.T) {
 					),
 					envoy.NewCluster(
 						"servicens3/servicename3",
-						5*time.Second,
+						envoy.ClusterConnectionOpts{
+							MaxConnections:     defaultMaxConnections,
+							MaxRequests:        defaultMaxConnections,
+							MaxPendingRequests: defaultMaxConnections,
+							MaxRetries:         defaultRetryCount,
+							ConnectTimeout:     5 * time.Second,
+						},
 						[]*endpoint.LbEndpoint{envoy.NewLBEndpoint("example.com", 80)},
 						false,
 						nil,
@@ -461,7 +502,13 @@ func TestIngressTranslator(t *testing.T) {
 				clusters: []*v3.Cluster{
 					envoy.NewCluster(
 						"servicens/servicename",
-						5*time.Second,
+						envoy.ClusterConnectionOpts{
+							MaxConnections:     defaultMaxConnections,
+							MaxRequests:        defaultMaxConnections,
+							MaxPendingRequests: defaultMaxConnections,
+							MaxRetries:         defaultRetryCount,
+							ConnectTimeout:     5 * time.Second,
+						},
 						lbEndpoints,
 						false,
 						nil,
@@ -515,7 +562,13 @@ func TestIngressTranslator(t *testing.T) {
 				clusters: []*v3.Cluster{
 					envoy.NewCluster(
 						"servicens/servicename",
-						5*time.Second,
+						envoy.ClusterConnectionOpts{
+							MaxConnections:     defaultMaxConnections,
+							MaxRequests:        defaultMaxConnections,
+							MaxPendingRequests: defaultMaxConnections,
+							MaxRetries:         defaultRetryCount,
+							ConnectTimeout:     5 * time.Second,
+						},
 						[]*endpoint.LbEndpoint{envoy.NewLBEndpoint("example.com", 80)},
 						false,
 						nil,
@@ -570,7 +623,13 @@ func TestIngressTranslator(t *testing.T) {
 				clusters: []*v3.Cluster{
 					envoy.NewCluster(
 						"servicens/servicename",
-						5*time.Second,
+						envoy.ClusterConnectionOpts{
+							MaxConnections:     defaultMaxConnections,
+							MaxRequests:        defaultMaxConnections,
+							MaxPendingRequests: defaultMaxConnections,
+							MaxRetries:         defaultRetryCount,
+							ConnectTimeout:     5 * time.Second,
+						},
 						[]*endpoint.LbEndpoint{envoy.NewLBEndpoint("example.com", 80)},
 						false,
 						nil,
@@ -705,7 +764,13 @@ func TestIngressTranslatorWithHTTPOptionDisabled(t *testing.T) {
 				clusters: []*v3.Cluster{
 					envoy.NewCluster(
 						"servicens/servicename",
-						5*time.Second,
+						envoy.ClusterConnectionOpts{
+							MaxConnections:     defaultMaxConnections,
+							MaxRequests:        defaultMaxConnections,
+							MaxPendingRequests: defaultMaxConnections,
+							MaxRetries:         defaultRetryCount,
+							ConnectTimeout:     5 * time.Second,
+						},
 						lbEndpoints,
 						false,
 						nil,
@@ -775,7 +840,13 @@ func TestIngressTranslatorWithHTTPOptionDisabled(t *testing.T) {
 				clusters: []*v3.Cluster{
 					envoy.NewCluster(
 						"servicens/servicename",
-						5*time.Second,
+						envoy.ClusterConnectionOpts{
+							MaxConnections:     defaultMaxConnections,
+							MaxRequests:        defaultMaxConnections,
+							MaxPendingRequests: defaultMaxConnections,
+							MaxRetries:         defaultRetryCount,
+							ConnectTimeout:     5 * time.Second,
+						},
 						lbEndpoints,
 						false,
 						nil,
@@ -868,7 +939,13 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 				clusters: []*v3.Cluster{
 					envoy.NewCluster(
 						"servicens/servicename",
-						5*time.Second,
+						envoy.ClusterConnectionOpts{
+							MaxConnections:     defaultMaxConnections,
+							MaxRequests:        defaultMaxConnections,
+							MaxPendingRequests: defaultMaxConnections,
+							MaxRetries:         defaultRetryCount,
+							ConnectTimeout:     5 * time.Second,
+						},
 						lbEndpoints,
 						false,
 						&envoycorev3.TransportSocket{
@@ -931,7 +1008,13 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 				clusters: []*v3.Cluster{
 					envoy.NewCluster(
 						"servicens/servicename",
-						5*time.Second,
+						envoy.ClusterConnectionOpts{
+							MaxConnections:     defaultMaxConnections,
+							MaxRequests:        defaultMaxConnections,
+							MaxPendingRequests: defaultMaxConnections,
+							MaxRetries:         defaultRetryCount,
+							ConnectTimeout:     5 * time.Second,
+						},
 						lbEndpoints,
 						true, /* http2 */
 						&envoycorev3.TransportSocket{
@@ -1000,7 +1083,13 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 				clusters: []*v3.Cluster{
 					envoy.NewCluster(
 						"servicens/servicename",
-						5*time.Second,
+						envoy.ClusterConnectionOpts{
+							MaxConnections:     defaultMaxConnections,
+							MaxRequests:        defaultMaxConnections,
+							MaxPendingRequests: defaultMaxConnections,
+							MaxRetries:         defaultRetryCount,
+							ConnectTimeout:     5 * time.Second,
+						},
 						lbHTTPSEndpoints,
 						false, /* http2 */
 						&envoycorev3.TransportSocket{
@@ -1069,7 +1158,13 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 				clusters: []*v3.Cluster{
 					envoy.NewCluster(
 						"servicens/servicename",
-						5*time.Second,
+						envoy.ClusterConnectionOpts{
+							MaxConnections:     defaultMaxConnections,
+							MaxRequests:        defaultMaxConnections,
+							MaxPendingRequests: defaultMaxConnections,
+							MaxRetries:         defaultRetryCount,
+							ConnectTimeout:     5 * time.Second,
+						},
 						lbHTTPSEndpoints,
 						true, /* http2 */
 						&envoycorev3.TransportSocket{
@@ -1169,7 +1264,13 @@ func TestIngressTranslatorHTTP01Challenge(t *testing.T) {
 				clusters: []*v3.Cluster{
 					envoy.NewCluster(
 						"simplens/cm-acme-http-solver",
-						5*time.Second,
+						envoy.ClusterConnectionOpts{
+							MaxConnections:     defaultMaxConnections,
+							MaxRequests:        defaultMaxConnections,
+							MaxPendingRequests: defaultMaxConnections,
+							MaxRetries:         defaultRetryCount,
+							ConnectTimeout:     5 * time.Second,
+						},
 						lbEndpointHTTP01Challenge,
 						false,
 						nil,
@@ -1269,7 +1370,13 @@ func TestIngressTranslatorDomainMappingDisableHTTP2(t *testing.T) {
 				clusters: []*v3.Cluster{
 					envoy.NewCluster(
 						"servicens/servicename",
-						5*time.Second,
+						envoy.ClusterConnectionOpts{
+							MaxConnections:     defaultMaxConnections,
+							MaxRequests:        defaultMaxConnections,
+							MaxPendingRequests: defaultMaxConnections,
+							MaxRetries:         defaultRetryCount,
+							ConnectTimeout:     5 * time.Second,
+						},
 						[]*endpoint.LbEndpoint{
 							envoy.NewLBEndpoint("kourier-internal.kourier-system.svc.cluster.local", 80),
 						},


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

configuring envoy connection parameters from ingress annotations resource by user defined

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
The current project only use default values envoy connection parameters and are not configured for connections to clusters created by ingress. now, can configuring envoy connection parameters from ingress annotations resource by user defined.
```

**Unit Test**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```Test
=== RUN   TestIngressTranslator
--- PASS: TestIngressTranslator (0.04s)
=== RUN   TestIngressTranslator/simple
    --- PASS: TestIngressTranslator/simple (0.01s)
=== RUN   TestIngressTranslator/tls
    --- PASS: TestIngressTranslator/tls (0.01s)
=== RUN   TestIngressTranslator/tls_redirect
    --- PASS: TestIngressTranslator/tls_redirect (0.01s)
=== RUN   TestIngressTranslator/tls_redirect_cluster_local
    --- PASS: TestIngressTranslator/tls_redirect_cluster_local (0.00s)
=== RUN   TestIngressTranslator/split
    --- PASS: TestIngressTranslator/split (0.01s)
=== RUN   TestIngressTranslator/path_defaulting
    --- PASS: TestIngressTranslator/path_defaulting (0.00s)
=== RUN   TestIngressTranslator/external_service
    --- PASS: TestIngressTranslator/external_service (0.00s)
=== RUN   TestIngressTranslator/external_service_without_service_port
    --- PASS: TestIngressTranslator/external_service_without_service_port (0.00s)
=== RUN   TestIngressTranslator/missing_service
{"level":"warn","ts":1657538878.371255,"logger":"fallback","caller":"generator/ingress_translator.go:193","msg":"Service 'servicens/servicename' not yet created"}
    --- PASS: TestIngressTranslator/missing_service (0.00s)
=== RUN   TestIngressTranslator/missing_endpoints
{"level":"warn","ts":1657538878.371395,"logger":"fallback","caller":"generator/ingress_translator.go:236","msg":"Endpoints 'servicens/servicename' not yet created"}
    --- PASS: TestIngressTranslator/missing_endpoints (0.00s)
PASS
```

**Envoy Config Dump**
```
"circuit_breakers": {
    "thresholds": [
     {
      "max_connections": 4294967295,
      "max_pending_requests": 4294967295,
      "max_requests": 4294967295,
      "max_retries": 10
     },
     {
      "priority": "HIGH",
      "max_connections": 4294967295,
      "max_pending_requests": 4294967295,
      "max_requests": 4294967295,
      "max_retries": 10
     }
    ]
}
```