### PR TITLE
Add lb-policy and hash-policy annotations to configure Envoy's load balancer [WIP]

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,10 +75,24 @@ const (
 	// ListenerPortAnnotationKey is the annotation key for assigning the ingress to a particular
 	// envoy listener port. Only applicable to internal services.
 	ListenerPortAnnotationKey = "kourier.knative.dev/listener-port"
+
+	// Load Balancing Policy annotation
+	lbPolicyAnnotationKey = "kourier.knative.dev/lb-policy"
+
+	// Hash Policy annotation
+	hashPolicyAnnotationKey = "kourier.knative.dev/hash-policy"
 )
 
 var disableHTTP2Annotation = kmap.KeyPriority{
 	disableHTTP2AnnotationKey,
+}
+
+var lbPolicyAnnotation = kmap.KeyPriority{
+	lbPolicyAnnotationKey,
+}
+
+var hashPolicyAnnotation = kmap.KeyPriority{
+	hashPolicyAnnotationKey,
 }
 
 // ServiceHostnames returns the external and internal service's respective hostname.
@@ -114,4 +128,14 @@ func ServingNamespace() string {
 // GetDisableHTTP2 specifies whether http2 is going to be disabled
 func GetDisableHTTP2(annotations map[string]string) (val string) {
 	return disableHTTP2Annotation.Value(annotations)
+}
+
+// GetLbPolicy specifies the load balancing policy
+func GetLbPolicy(annotations map[string]string) (val string) {
+	return lbPolicyAnnotation.Value(annotations)
+}
+
+// GetHashPolicy specifies the hash policy
+func GetHashPolicy(annotations map[string]string) (val string) {
+	return hashPolicyAnnotation.Value(annotations)
 }


### PR DESCRIPTION
# Changes

This PR adds two annotations on Knative services to configure Envoy's load balancer, to be used for example as the following:
```
apiVersion: serving.knative.dev/v1
kind: Service
metadata:
  annotations:
    kourier.knative.dev/lb-policy: ring_hash
    kourier.knative.dev/hash-policy: '{"query_parameter":{"name":"session_id"}}'
```

This PR makes it possible for related requests (in the example requests with the same `session_id` query parameter) to be routed to the same replica (as long as the set of replicas remains unchanged). In particular, it should permit caching session state in a pod.

See Envoy's documentation for `lb_policy` in https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-enum-config-cluster-v3-cluster-lbpolicy and for `hash_policy` in https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-msg-config-route-v3-routeaction-hashpolicy.

Invalid annotation values are logged (WARN severity) and ignored.

This PR does not include tests or documentation yet, and does not handle yet all the possible load balancing and hash policies supported by Envoy.

/kind enhancement