### PR TITLE
Drop maistra 2.3 from CI

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -25,7 +25,6 @@ jobs:
         - v1.27.x
 
         gateway:
-        - quay.io/maistra-dev/proxyv2-ubi8:2.3-latest
         - quay.io/maistra-dev/proxyv2-ubi8:2.4-latest
         - docker.io/envoyproxy/envoy:v1.24-latest
         - docker.io/envoyproxy/envoy:v1.25-latest


### PR DESCRIPTION
As per title, this patch drops maistra 2.3 from CI.

2.4 was released and downstream also started testing with 2.4.

/kind cleanup

```release-note
NONE
```

**Docs**

```docs
NONE
```

/cc @ReToCode @norbjd 