### PR TITLE
Bump envoy version to 1.25 and 1.26

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -26,8 +26,8 @@ jobs:
 
         gateway:
         - quay.io/maistra-dev/proxyv2-ubi8:2.4-latest
-        - docker.io/envoyproxy/envoy:v1.24-latest
         - docker.io/envoyproxy/envoy:v1.25-latest
+        - docker.io/envoyproxy/envoy:v1.26-latest
 
         upstream-tls:
         - plain

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -50,7 +50,7 @@ spec:
             - --log-level info
           command:
             - /usr/local/bin/envoy
-          image: docker.io/envoyproxy/envoy:v1.24-latest
+          image: docker.io/envoyproxy/envoy:v1.25-latest
           name: kourier-gateway
           ports:
             - name: http2-external


### PR DESCRIPTION
As per title, this patch bumps envoy version to 1.25 and 1.26.

**Release Note**

```release-note
Kourier Gateway uses envoy 1.25 by default.
```
