### PR TITLE
Bump golang and kind version

### DIFF
--- a/.github/workflows/kind-e2e-upgrade.yaml
+++ b/.github/workflows/kind-e2e-upgrade.yaml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.25.x
         - v1.26.x
         - v1.27.x
+        - v1.28.x
 
         upstream-traffic:
         - plain
@@ -37,10 +37,10 @@ jobs:
       KIND_CLUSTER_NAME: "kourier-integration"
 
     steps:
-    - name: Set up Go 1.19.x
+    - name: Set up Go 1.21.x
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19.x
+        go-version: 1.21.x
 
     - uses: ko-build/setup-ko@v0.6
 

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.25.x
         - v1.26.x
         - v1.27.x
+        - v1.28.x
 
         gateway:
         - quay.io/maistra-dev/proxyv2-ubi8:2.4-latest
@@ -41,10 +41,10 @@ jobs:
       CLUSTER_SUFFIX: c${{ github.run_id }}.local
 
     steps:
-    - name: Set up Go 1.19.x
+    - name: Set up Go 1.21.x
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19.x
+        go-version: 1.21.x
 
     - uses: ko-build/setup-ko@v0.6
 


### PR DESCRIPTION
# Changes
- Bumps golang to version 1.21
- Bumps kind version range from 1.26-1.28

Fixes #1112

Depends on https://github.com/chainguard-dev/actions/pull/321
