### PR TITLE
[release-1.10] Rebuild using Go 1.20.10 (to address CVEs)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,9 @@
 module knative.dev/net-kourier
 
+// This comment was added so CI would trigger a point release with a
+// newer version of Go
+// Fixes: https://groups.google.com/g/golang-announce/c/iNNxDTCjZvo
+
 go 1.18
 
 require (


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/iNNxDTCjZvo

Using new CI images from https://github.com/knative/infra/pull/232