### PR TITLE
Increase kourier controller CPU limit

### DIFF
--- a/config/300-controller.yaml
+++ b/config/300-controller.yaml
@@ -94,7 +94,7 @@ spec:
               cpu: 200m
               memory: 200Mi
             limits:
-              cpu: 500m
+              cpu: "1"
               memory: 500Mi
       restartPolicy: Always
       serviceAccountName: net-kourier


### PR DESCRIPTION
# Changes
- Increases the CPU limits of net-kourier controller to avoid slow startup with ~500 KSVCs

**Release Note**

```release-note
The CPU limit of kourier controller was increased to avoid CPU limitation issues in larger installations
```

