### PR TITLE
Increase Kourier gateway CPU limit

### DIFF
--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -113,7 +113,7 @@ spec:
               cpu: 200m
               memory: 200Mi
             limits:
-              cpu: 500m
+              cpu: "1"
               memory: 500Mi
       volumes:
         - name: config-volume


### PR DESCRIPTION
Increases the CPU limits of kourier gateway instead of controller to avoid readliness probe failure ~500 KSVCs.

**Release Note**

```release-note
The CPU limit of kourier Gateway limit is now increased to avoid CPU limitation issues in larger installations.
```

/cc @ReToCode @skonto 