### PR TITLE
Bump envoy image version to 1.26+

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -25,8 +25,9 @@ jobs:
 
         gateway:
         - quay.io/maistra-dev/proxyv2-ubi8:2.4-latest
-        - docker.io/envoyproxy/envoy:v1.25-latest
         - docker.io/envoyproxy/envoy:v1.26-latest
+        - docker.io/envoyproxy/envoy:v1.27-latest
+        - docker.io/envoyproxy/envoy:v1.28-latest
 
         upstream-tls:
         - plain

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -50,7 +50,7 @@ spec:
             - --log-level info
           command:
             - /usr/local/bin/envoy
-          image: docker.io/envoyproxy/envoy:v1.25-latest
+          image: docker.io/envoyproxy/envoy:v1.26-latest
           name: kourier-gateway
           ports:
             - name: http2-external


### PR DESCRIPTION
**Release Note**

```release-note
Kourier Gateway uses envoy 1.26 by default
```