### PR TITLE
Drop deprecated envoy config

### DIFF
--- a/config/200-bootstrap.yaml
+++ b/config/200-bootstrap.yaml
@@ -114,8 +114,3 @@ data:
       address:
         pipe:
           path: /tmp/envoy.admin
-    layered_runtime:
-      layers:
-        - name: static-layer
-          static_layer:
-            envoy.reloadable_features.override_request_timeout_by_gateway_timeout: false


### PR DESCRIPTION
# Changes
- `override_request_timeout_by_gateway_timeout` was deprecated in [envoy 1.22](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.22/v1.22.0.html)
- Removing it from the bootstrap config

Envoy release notes for this:

> changed the http status code to 504 from 408 if the request times out after the request is completed

/hold for tests

Fixes #1126