### PR TITLE
[main] Support multiple ingress classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ Ensure that the file was updated successfully:
 kubectl get configmap config-kourier --namespace knative-serving --output yaml
 ```
 
+## Ingress class
+
+Kourier uses the `kourier.ingress.networking.knative.dev` ingress class by default.
+However, in some cases it may be useful to use multiple ingress classes.
+
+You can modify the default ingress class by `KOURIER_INGRESS_CLASS_NAME` env variable.
+
 ### LoadBalancer configuration:
 
 We need to:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,9 +58,6 @@ const (
 	// GatewayNamespaceEnv is an env variable specifying where the gateway is deployed.
 	GatewayNamespaceEnv = "KOURIER_GATEWAY_NAMESPACE"
 
-	// KourierIngressClassName is the class name to reconcile.
-	KourierIngressClassName = "kourier.ingress.networking.knative.dev"
-
 	// disableHTTP2AnnotationKey is the annotation key attached to a Knative Domain Mapping
 	// to indicate that http2 should not be enabled for it.
 	disableHTTP2AnnotationKey = "kourier.knative.dev/disable-http2"
@@ -72,6 +69,9 @@ const (
 	// CipherSuites is the cipher suites for TLS external listener.
 	cipherSuites = "cipher-suites"
 )
+
+// KourierIngressClassName is the class name to reconcile.
+var KourierIngressClassName = GetIngressClassName()
 
 var disableHTTP2Annotation = kmap.KeyPriority{
 	disableHTTP2AnnotationKey,
@@ -97,4 +97,13 @@ func GatewayNamespace() string {
 // GetDisableHTTP2 specifies whether http2 is going to be disabled
 func GetDisableHTTP2(annotations map[string]string) (val string) {
 	return disableHTTP2Annotation.Value(annotations)
+}
+
+func GetIngressClassName() string {
+	defaultIngressClassName := "kourier.ingress.networking.knative.dev"
+	className := os.Getenv("KOURIER_INGRESS_CLASS_NAME")
+	if className != "" {
+		return className
+	}
+	return defaultIngressClassName
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes
- Make the default `kourier.ingress.networking.knative.dev` ingress class configurable.

Fixes #1186 

Example how it works https://github.com/knative-extensions/net-kourier/issues/1186#issuecomment-1890447946
