### PR TITLE
fix: Add metric port to pods and service

### DIFF
--- a/config/300-controller.yaml
+++ b/config/300-controller.yaml
@@ -70,6 +70,9 @@ spec:
           - name: http2-xds
             containerPort: 18000
             protocol: TCP
+          - name: metrics
+            containerPort: 9090
+            protocol: TCP
           readinessProbe:
             grpc:
               port: 18000
@@ -115,6 +118,10 @@ spec:
       port: 18000
       protocol: TCP
       targetPort: 18000
+    - name: http-metrics
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
   selector:
     app: net-kourier-controller
   type: ClusterIP

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -68,6 +68,9 @@ spec:
             - name: https-probe
               containerPort: 9443
               protocol: TCP
+            - name: metrics
+              containerPort: 9000
+              protocol: TCP
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->
This allows the usage of Prometheus PodMonitors and/or ServiceMonitors to configure scraping of metrics.  This is often preferred over the annotations on the pods.  This is also more inline with the rest of Knative.

- Add metric port definition to both gateway pods and controller pods.
- Add metric port to controller service

NOTE: Did not add metric port to gateway services as those often are exposed and exposing the metrics via those services is probably not desired in most cases.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Add support for Prometheus ServiceMonitor/PodMonitor
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

Additionally ServiceMonitors and PodMonitors should probably be provided somewhere, maybe over in https://github.com/knative-extensions/monitoring with the rest for base Knative?