### PR TITLE
Fix gateway preStop hook

### DIFF
--- a/config/200-bootstrap.yaml
+++ b/config/200-bootstrap.yaml
@@ -72,6 +72,15 @@ data:
                                       exact: GET
                               route:
                                 cluster: service_stats
+                            - match:
+                                safe_regex:
+                                  regex: '/healthcheck/(fail|ok)'
+                                headers:
+                                  - name: ':method'
+                                    string_match:
+                                      exact: POST
+                              route:
+                                cluster: service_stats
       clusters:
         - name: service_stats
           connect_timeout: 0.250s

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -85,7 +85,15 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh","-c","curl -X POST --unix /tmp/envoy.admin http://localhost/healthcheck/fail; sleep 15"]
+                command:
+                - /bin/bash
+                - -c
+                - |-
+                  set -e
+
+                  exec 3<>/dev/tcp/localhost/9000
+                  echo -e "POST /healthcheck/fail HTTP/1.1\nHost: localhost\nConnection: close\n\n" >&3
+                  sleep 15
           readinessProbe:
             httpGet:
               httpHeaders:


### PR DESCRIPTION
# Changes

- :bug: fix gateway preStop hook

/kind bug

While investigating to understand the issue https://github.com/knative-extensions/net-kourier/issues/1118, I've noticed that the current `preStop` hook for the gateway (envoy) did not work at all. The reason is that `curl` is not installed in Envoy's default image (it might have been here at some point, but not anymore). As a result, the call to `/healthcheck/fail`, to make Envoy fail health checks before shutting down, did not work.

To replace `curl`, there were many solutions I've thought of:

1. build a dedicated Envoy image with `curl` in it: too overkill for our needs (I don't think we want to maintain a separate Envoy image just for a hook). The ideal solution would have been to have `curl` installed in the envoy official image, but we can't expect that
2. install a static binary of `curl` in an init container and copy it to envoy container using a volume: this looks way too magic. The reason we need a static binary is we can't just copy the `curl` binary from `apt install -y curl` because this needs some other dependencies
3. same as 2, but don't use `curl`, e.g. install `nc` or `socat` (or other tools I'm not aware of) to be able to communicate with the `/tmp/envoy.admin` socket
4. do an HTTP request to the admin endpoint with only shell tools

I've chosen 4 because it seemed to be the "least" impactful change (having an init container to install a binary used only in the hook is... meh). To communicate with Envoy admin interface using default shell tools, I had to "open" the route to `/healthcheck/fail` endpoint. We need to pass through the HTTP endpoint because we can't write directly to the socket.

It was not really easy to see this error, as no `FailedPreStopHook` event were sent, since the last command of the hook (`sleep 15`) did succeed. This is why I've also added a `set -e` command in the hook: if one command fails in the script, it will return an error, and throw a `FailedPreStopHook`.

### Alternative

An other alternative (simpler) is to only keep the pause (`sleep 15`) in the `preStop` hook, like in this [tutorial](https://kubernetes.io/docs/tutorials/services/pods-and-endpoint-termination-flow/). But I'm not sure that in this case, when the pod is in `Terminating` state, no traffic will be redirected to it. Let's discuss in the comments if you feel this is a better solution.

**Release Note**

```release-note
Fix gateway preStop hook
```