### PR TITLE
Read external ports from a configmap.

### DIFF
--- a/pkg/config/configmap.go
+++ b/pkg/config/configmap.go
@@ -33,6 +33,12 @@ const (
 	// ConfigName is the name of config map for Kourier.
 	ConfigName = "config-kourier"
 
+	// httpPortExternal is the config map key for HTTP port for external availability.
+	httpPortExternal = "http-port-external"
+
+	// httpsPortExternal is the config map key for HTTPS port for external availability.
+	httpsPortExternal = "https-port-external"
+
 	// enableServiceAccessLoggingKey is the config map key for enabling service related
 	// access logging.
 	enableServiceAccessLoggingKey = "enable-service-access-logging"
@@ -56,6 +62,8 @@ const (
 
 func DefaultConfig() *Kourier {
 	return &Kourier{
+		HTTPPortExternal:           HTTPPortExternal,
+		HTTPSPortExternal:          HTTPSPortExternal,
 		EnableServiceAccessLogging: true, // true is the default for backwards-compat
 		EnableProxyProtocol:        false,
 		ClusterCertSecret:          "",
@@ -71,6 +79,8 @@ func NewConfigFromMap(configMap map[string]string) (*Kourier, error) {
 	nc := DefaultConfig()
 
 	if err := cm.Parse(configMap,
+		cm.AsUint32(httpPortExternal, &nc.HTTPPortExternal),
+		cm.AsUint32(httpsPortExternal, &nc.HTTPSPortExternal),
 		cm.AsBool(enableServiceAccessLoggingKey, &nc.EnableServiceAccessLogging),
 		cm.AsBool(enableProxyProtocol, &nc.EnableProxyProtocol),
 		cm.AsString(clusterCert, &nc.ClusterCertSecret),
@@ -132,6 +142,10 @@ func NewConfigFromConfigMap(config *corev1.ConfigMap) (*Kourier, error) {
 // Kourier includes the configuration for Kourier.
 // +k8s:deepcopy-gen=true
 type Kourier struct {
+	// HTTPPortExternal is the port for external availability.
+	HTTPPortExternal uint32
+	// HTTPSPortExternal is the port for external HTTPS availability.
+	HTTPSPortExternal uint32
 	// EnableServiceAccessLogging specifies whether requests reaching the Kourier gateway
 	// should be logged.
 	EnableServiceAccessLogging bool

--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -240,7 +240,7 @@ func generateListenersAndRouteConfigsAndClusters(
 	externalTLSManager := envoy.NewHTTPConnectionManager(externalTLSRouteConfig.Name, cfg.Kourier)
 	localManager := envoy.NewHTTPConnectionManager(localRouteConfig.Name, cfg.Kourier)
 
-	externalHTTPEnvoyListener, err := envoy.NewHTTPListener(externalManager, config.HTTPPortExternal, cfg.Kourier.EnableProxyProtocol)
+	externalHTTPEnvoyListener, err := envoy.NewHTTPListener(externalManager, cfg.Kourier.HTTPPortExternal, cfg.Kourier.EnableProxyProtocol)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -326,7 +326,7 @@ func generateListenersAndRouteConfigsAndClusters(
 	// using a single cert for all the services if the creds are given via ENV.
 	if len(externalSNIMatches) > 0 {
 		externalHTTPSEnvoyListener, err := envoy.NewHTTPSListenerWithSNI(
-			externalTLSManager, config.HTTPSPortExternal,
+			externalTLSManager, cfg.Kourier.HTTPSPortExternal,
 			externalSNIMatches, cfg.Kourier,
 		)
 		if err != nil {
@@ -454,7 +454,7 @@ func newExternalEnvoyListenerWithOneCert(ctx context.Context, manager *httpconnm
 		return nil, err
 	}
 
-	return envoy.NewHTTPSListener(config.HTTPSPortExternal, []*v3.FilterChain{filterChain}, cfg.EnableProxyProtocol)
+	return envoy.NewHTTPSListener(cfg.HTTPSPortExternal, []*v3.FilterChain{filterChain}, cfg.EnableProxyProtocol)
 }
 
 func newLocalEnvoyListenerWithOneCertFilterChain(ctx context.Context, manager *httpconnmanagerv3.HttpConnectionManager, kubeClient kubeclient.Interface, cfg *config.Kourier) (*v3.FilterChain, error) {


### PR DESCRIPTION
/kind gift

Hi, this PR makes external ports configurable, optionally reading them from a config map and preserving backward compatibility. Please let me know how it looks like.

Issue: https://github.com/knative-extensions/net-kourier/issues/1195