### PR TITLE
Gracefully drain connections when stopping the gateway

### DIFF
--- a/config/200-bootstrap.yaml
+++ b/config/200-bootstrap.yaml
@@ -74,7 +74,7 @@ data:
                                 cluster: service_stats
                             - match:
                                 safe_regex:
-                                  regex: '/healthcheck/(fail|ok)'
+                                  regex: '/drain_listeners'
                                 headers:
                                   - name: ':method'
                                     string_match:

--- a/config/200-bootstrap.yaml
+++ b/config/200-bootstrap.yaml
@@ -72,6 +72,15 @@ data:
                                       exact: GET
                               route:
                                 cluster: service_stats
+                            - match:
+                                safe_regex:
+                                  regex: '/healthcheck/(fail|ok)'
+                                headers:
+                                  - name: ':method'
+                                    string_match:
+                                      exact: POST
+                              route:
+                                cluster: service_stats
       clusters:
         - name: service_stats
           connect_timeout: 0.250s

--- a/config/200-bootstrap.yaml
+++ b/config/200-bootstrap.yaml
@@ -72,15 +72,6 @@ data:
                                       exact: GET
                               route:
                                 cluster: service_stats
-                            - match:
-                                safe_regex:
-                                  regex: '/drain_listeners'
-                                headers:
-                                  - name: ':method'
-                                    string_match:
-                                      exact: POST
-                              route:
-                                cluster: service_stats
       clusters:
         - name: service_stats
           connect_timeout: 0.250s

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -93,7 +93,22 @@ spec:
 
                   exec 3<>/dev/tcp/localhost/9000
                   echo -e "POST /healthcheck/fail HTTP/1.1\nHost: localhost\nConnection: close\n\n" >&3
-                  sleep 15
+
+                  active_connections=1
+
+                  while [ "$active_connections" != "0" ]
+                  do
+                      sleep 1
+
+                      exec 3<>/dev/tcp/localhost/9000
+                      # get downstream_cx_active (active requests) for all "public" listeners (8080, 8081, 8443)
+                      echo -e "GET /stats?filter=listener.0.0.0.0_%288080%7C8081%7C8443%29.downstream_cx_active&format=text HTTP/1.1\nHost: localhost\nConnection: close\n\n" >&3
+
+                      active_connections=$(cat <&3 | grep 'downstream_cx_active' | awk 'BEGIN{active=0} {active+=$NF} END{print active}')
+                      echo "Active connections: $active_connections"
+                  done
+
+                  echo "No more active connections!"
           readinessProbe:
             httpGet:
               httpHeaders:
@@ -123,6 +138,7 @@ spec:
             limits:
               cpu: "1"
               memory: 500Mi
+      terminationGracePeriodSeconds: 120
       volumes:
         - name: config-volume
           configMap:

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -91,24 +91,40 @@ spec:
                 - |-
                   set -e
 
-                  exec 3<>/dev/tcp/localhost/9000
-                  echo -e "POST /healthcheck/fail HTTP/1.1\nHost: localhost\nConnection: close\n\n" >&3
+                  # helper method to do a HTTP call to the admin interface
+                  function http_admin_request() {
+                    method="$1"
+                    path="$2"
 
+                    {
+                      echo -e >&3 "$method $path HTTP/1.1\nHost: localhost\nConnection: close\n\n"
+                      cat <&3
+                    } 3<>/dev/tcp/localhost/9000
+                  }
+
+                  function log() {
+                    echo "[$(date --iso-8601=seconds --utc)] $1" > /proc/1/fd/1
+                  }
+
+                  log "Start draining process"
+
+                  # first, run the drain process
+                  http_admin_request POST "/drain_listeners?graceful&skip_exit"
+
+                  # then, wait until there is no more active connections
                   active_connections=1
-
                   while [ "$active_connections" != "0" ]
                   do
                       sleep 1
 
-                      exec 3<>/dev/tcp/localhost/9000
-                      # get downstream_cx_active (active requests) for all "public" listeners (8080, 8081, 8443)
-                      echo -e "GET /stats?filter=listener.0.0.0.0_%288080%7C8081%7C8443%29.downstream_cx_active&format=text HTTP/1.1\nHost: localhost\nConnection: close\n\n" >&3
-
-                      active_connections=$(cat <&3 | grep 'downstream_cx_active' | awk 'BEGIN{active=0} {active+=$NF} END{print active}')
-                      echo "Active connections: $active_connections"
+                      # we use /stats endpoint to find out the number of active connections to listeners, excluding the admin one
+                      active_connections=$(http_admin_request GET "/stats?filter=listener.0.0.0.0_%5B%5E9%5D%5Cd%2B.downstream_cx_active&format=text" | \
+                        grep 'downstream_cx_active' | \
+                        awk 'BEGIN{active=0} {active+=$NF} END{print active}')
+                      log "Number of active connections: $active_connections"
                   done
 
-                  echo "No more active connections!"
+                  log "No more active connections, safely exiting"
           readinessProbe:
             httpGet:
               httpHeaders:
@@ -138,7 +154,7 @@ spec:
             limits:
               cpu: "1"
               memory: 500Mi
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 300
       volumes:
         - name: config-volume
           configMap:

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -48,8 +48,16 @@ spec:
             - --base-id 1
             - -c /tmp/config/envoy-bootstrap.yaml
             - --log-level info
+            - --drain-time-s $(DRAIN_TIME_SECONDS)
+            - --drain-strategy immediate
+            - --parent-shutdown-time-s $(PARENT_SHUTDOWN_TIME_SECONDS)
           command:
             - /usr/local/bin/envoy
+          env:
+            - name: DRAIN_TIME_SECONDS
+              value: "60"
+            - name: PARENT_SHUTDOWN_TIME_SECONDS
+              value: "900"
           image: docker.io/envoyproxy/envoy:v1.26-latest
           name: kourier-gateway
           ports:
@@ -91,40 +99,12 @@ spec:
                 - |-
                   set -e
 
-                  # helper method to do a HTTP call to the admin interface
-                  function http_admin_request() {
-                    method="$1"
-                    path="$2"
-
-                    {
-                      echo -e >&3 "$method $path HTTP/1.1\nHost: localhost\nConnection: close\n\n"
+                  {
+                      echo -e >&3 "POST /drain_listeners?graceful HTTP/1.1\nHost: localhost\nConnection: close\n\n"
                       cat <&3
-                    } 3<>/dev/tcp/localhost/9000
-                  }
+                  } 3<>/dev/tcp/localhost/9000
 
-                  function log() {
-                    echo "[$(date --iso-8601=seconds --utc)] $1" > /proc/1/fd/1
-                  }
-
-                  log "Start draining process"
-
-                  # first, run the drain process
-                  http_admin_request POST "/drain_listeners?graceful&skip_exit"
-
-                  # then, wait until there is no more active connections
-                  active_connections=1
-                  while [ "$active_connections" != "0" ]
-                  do
-                      sleep 1
-
-                      # we use /stats endpoint to find out the number of active connections to listeners, excluding the admin one
-                      active_connections=$(http_admin_request GET "/stats?filter=listener.0.0.0.0_%5B%5E9%5D%5Cd%2B.downstream_cx_active&format=text" | \
-                        grep 'downstream_cx_active' | \
-                        awk 'BEGIN{active=0} {active+=$NF} END{print active}')
-                      log "Number of active connections: $active_connections"
-                  done
-
-                  log "No more active connections, safely exiting"
+                  sleep $DRAIN_TIME_SECONDS
           readinessProbe:
             httpGet:
               httpHeaders:
@@ -154,7 +134,7 @@ spec:
             limits:
               cpu: "1"
               memory: 500Mi
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 900
       volumes:
         - name: config-volume
           configMap:

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -91,17 +91,26 @@ spec:
             preStop:
               exec:
                 command:
-                - /bin/bash
-                - -c
+                - perl
+                - -e
                 - |-
-                  set -e
+                  use strict;
+                  use warnings;
+                  use IO::Socket qw(AF_UNIX SOCK_STREAM SHUT_WR);
 
-                  {
-                      echo -e >&3 "POST /drain_listeners?graceful HTTP/1.1\nHost: localhost\nConnection: close\n\n"
-                      cat <&3
-                  } 3<>/dev/tcp/localhost/9000
+                  my $client = IO::Socket->new(
+                    Domain => IO::Socket::AF_UNIX,
+                    Type   => IO::Socket::SOCK_STREAM,
+                    Peer   => "/tmp/envoy.admin"
+                  ) || die "Can't open socket: $IO::Socket::errstr";
+                  $client->autoflush(1);
 
-                  sleep $DRAIN_TIME_SECONDS
+                  $client->send("POST /drain_listeners?graceful HTTP/1.1\nHost: localhost\nConnection: close\n\n");
+                  $client->shutdown(IO::Socket::SHUT_WR);
+
+                  $client->close();
+
+                  sleep $ENV{DRAIN_TIME_SECONDS};
           readinessProbe:
             httpGet:
               httpHeaders:

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -85,7 +85,15 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh","-c","curl -X POST --unix /tmp/envoy.admin http://localhost/healthcheck/fail; sleep 15"]
+                command:
+                - /bin/bash
+                - -c
+                - |-
+                  set -e
+
+                  exec 3<>/dev/tcp/localhost/9000
+                  echo -e "POST /healthcheck/fail HTTP/1.1\nHost: localhost\nConnection: close\n\n" >&3
+                  sleep 15
           readinessProbe:
             httpGet:
               httpHeaders:

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -50,14 +50,11 @@ spec:
             - --log-level info
             - --drain-time-s $(DRAIN_TIME_SECONDS)
             - --drain-strategy immediate
-            - --parent-shutdown-time-s $(PARENT_SHUTDOWN_TIME_SECONDS)
           command:
             - /usr/local/bin/envoy
           env:
             - name: DRAIN_TIME_SECONDS
-              value: "60"
-            - name: PARENT_SHUTDOWN_TIME_SECONDS
-              value: "900"
+              value: "15"
           image: docker.io/envoyproxy/envoy:v1.26-latest
           name: kourier-gateway
           ports:
@@ -134,7 +131,6 @@ spec:
             limits:
               cpu: "1"
               memory: 500Mi
-      terminationGracePeriodSeconds: 900
       volumes:
         - name: config-volume
           configMap:


### PR DESCRIPTION
# Changes

- :bug: fix gateway preStop hook
- :gift: gracefully drain connections when stopping the gateway

/kind enhancement

This PR supersedes #1200 (click for more details, but TL;DR: today's `preStop` hook doesn't work, because `curl` is not installed in the gateway image).

When the gateway stops, we want to gracefully drain existing connections to prevent users with in-flight requests getting rejected with 5xx errors. To do so, we just need to drain the listeners using [Envoy admin interface and `/drain_listeners?graceful` endpoint](https://www.envoyproxy.io/docs/envoy/v1.26.0/operations/admin#operations-admin-interface-drain).

The `/drain_listeners?graceful` endpoint starts the graceful drain process, but returns immediately. The drain process is configured with `--drain-time-s $(DRAIN_TIME_SECONDS) --drain-strategy immediate`, so the drain will be finished after `DRAIN_TIME_SECONDS`. All connections that couldn't finish after `DRAIN_TIME_SECONDS` will be automatically closed, so this can be configured through the environment variable. People might need to also update `terminationGracePeriodSeconds` depending on their use case (default: 30s).

The reason why I've used `perl` is 1. `perl` is available inside Envoy images and 2. it provides a nice way to connect to Unix socket `/tmp/envoy.admin`. There is also a solution using plain `bash`: https://github.com/knative-extensions/net-kourier/compare/main...norbjd:5be667d697ba34c65946ed42bf4b9533cc27b4c5, but this requires extra changes.

Fixes #1118.

**Release Note**

```release-note
Gracefully drain connections when stopping the gateway
```