### PR TITLE
drop k8s 1.27 from kind testing

### DIFF
--- a/.github/workflows/kind-e2e-upgrade.yaml
+++ b/.github/workflows/kind-e2e-upgrade.yaml
@@ -20,8 +20,8 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.27.x
         - v1.28.x
+        - v1.29.x
 
         upstream-traffic:
         - plain

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -20,8 +20,8 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.27.x
         - v1.28.x
+        - v1.29.x
 
         gateway:
         - quay.io/maistra-dev/proxyv2-ubi8:2.4-latest


### PR DESCRIPTION
# Changes

- drop k8s v1.27 from kind testing
- add k8s v1.29 to kind testing

PS: Bump of client libraries will happen in https://github.com/knative/pkg/issues/2958
