### PR TITLE
Increase gateway memory limit

### DIFF
--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -114,7 +114,7 @@ spec:
               memory: 200Mi
             limits:
               cpu: "1"
-              memory: 500Mi
+              memory: 800Mi
       volumes:
         - name: config-volume
           configMap:


### PR DESCRIPTION
# Changes
- Increase 3scale-kourier-gateway memory limit

Fixes https://github.com/knative/serving/issues/15052


**Release Note**
```release-note
The default memory limit of 3scale-kourier-gateway was increased to prevent OOMKilled on peak load scenarios
```
