### PR TITLE
Add RetryPolicy on VirtualHost for upstream transient connection issues

### DIFF
--- a/pkg/envoy/api/virtual_host_test.go
+++ b/pkg/envoy/api/virtual_host_test.go
@@ -22,6 +22,7 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	"gotest.tools/v3/assert"
 )
 
@@ -45,7 +46,7 @@ func TestVirtualHostWithExtAuthz(t *testing.T) {
 	domains := []string{"foo", "bar"}
 	routes := []*route.Route{{Name: "baz"}}
 
-	got := NewVirtualHost(name, domains, routes, route.WithExtAuthz(nil))
+	got := NewVirtualHost(name, domains, routes, WithExtAuthz(nil))
 	want := &route.VirtualHost{
 		Name:    name,
 		Domains: domains,
@@ -63,7 +64,7 @@ func TestVirtualHostWithRetryOnTransientUpstreamFailure(t *testing.T) {
 	domains := []string{"foo", "bar"}
 	routes := []*route.Route{{Name: "baz"}}
 
-	got := NewVirtualHost(name, domains, routes, route.WithRetryOnTransientUpstreamFailure())
+	got := NewVirtualHost(name, domains, routes, WithRetryOnTransientUpstreamFailure())
 	want := &route.VirtualHost{
 		Name:        name,
 		Domains:     domains,

--- a/pkg/envoy/api/virtual_host_test.go
+++ b/pkg/envoy/api/virtual_host_test.go
@@ -66,9 +66,9 @@ func TestVirtualHostWithRetryOnTransientUpstreamFailure(t *testing.T) {
 
 	got := NewVirtualHost(name, domains, routes, WithRetryOnTransientUpstreamFailure())
 	want := &route.VirtualHost{
-		Name:        name,
-		Domains:     domains,
-		Routes:      routes,
+		Name:    name,
+		Domains: domains,
+		Routes:  routes,
 		RetryPolicy: &route.RetryPolicy{
 			RetryOn:    "reset,connect-failure",
 			NumRetries: wrapperspb.UInt32(1),

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -256,7 +256,7 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 
 		var virtualHost, virtualTLSHost *route.VirtualHost
 		// TODO(norbjd): do we want to enable this by default?
-		virtualHostOptions := []route.VirtualHostOption{
+		virtualHostOptions := []envoy.VirtualHostOption{
 			envoy.WithRetryOnTransientUpstreamFailure(),
 		}
 

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -1559,7 +1559,7 @@ func TestIngressTranslatorHTTP01Challenge(t *testing.T) {
 						""),
 					},
 					route.WithRetryOnTransientUpstreamFailure(),
-					route.WithExtAuthz(map[string]string{"client": "kourier", "visibility": "ExternalIP"})
+					route.WithExtAuthz(map[string]string{"client": "kourier", "visibility": "ExternalIP"}),
 				),
 			}
 

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -87,6 +87,7 @@ func TestIngressTranslator(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -152,6 +153,7 @@ func TestIngressTranslator(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -227,6 +229,7 @@ func TestIngressTranslator(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -301,6 +304,7 @@ func TestIngressTranslator(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 			vHostsRedirect := []*route.VirtualHost{
@@ -321,6 +325,7 @@ func TestIngressTranslator(t *testing.T) {
 						}},
 						"/test"),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -397,6 +402,7 @@ func TestIngressTranslator(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -520,6 +526,7 @@ func TestIngressTranslator(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -596,6 +603,7 @@ func TestIngressTranslator(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -656,6 +664,7 @@ func TestIngressTranslator(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -717,6 +726,7 @@ func TestIngressTranslator(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -854,6 +864,7 @@ func TestIngressTranslatorWithHTTPOptionDisabled(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 			return &translatedIngress{
@@ -929,6 +940,7 @@ func TestIngressTranslatorWithHTTPOptionDisabled(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -1041,6 +1053,7 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						""),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -1115,6 +1128,7 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						""),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -1190,6 +1204,7 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						""),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -1265,6 +1280,7 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						""),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -1331,6 +1347,7 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						""),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -1401,6 +1418,7 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						""),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -1525,7 +1543,7 @@ func TestIngressTranslatorHTTP01Challenge(t *testing.T) {
 		},
 		want: func() *translatedIngress {
 			vHosts := []*route.VirtualHost{
-				envoy.NewVirtualHostWithExtAuthz(
+				envoy.NewVirtualHost(
 					"(simplens/simplename).Rules[0]",
 					map[string]string{"client": "kourier", "visibility": "ExternalIP"},
 					[]string{"foo.example.com", "foo.example.com:*"},
@@ -1540,6 +1558,8 @@ func TestIngressTranslatorHTTP01Challenge(t *testing.T) {
 						nil,
 						""),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
+					route.WithExtAuthz(map[string]string{"client": "kourier", "visibility": "ExternalIP"})
 				),
 			}
 
@@ -1652,6 +1672,7 @@ func TestIngressTranslatorDomainMappingDisableHTTP2(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"bar.default.svc.cluster.local"),
 					},
+					route.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -1545,7 +1545,6 @@ func TestIngressTranslatorHTTP01Challenge(t *testing.T) {
 			vHosts := []*route.VirtualHost{
 				envoy.NewVirtualHost(
 					"(simplens/simplename).Rules[0]",
-					map[string]string{"client": "kourier", "visibility": "ExternalIP"},
 					[]string{"foo.example.com", "foo.example.com:*"},
 					[]*route.Route{envoy.NewRouteExtAuthzDisabled(
 						"(simplens/simplename).Rules[0].Paths[/.well-known/acme-challenge/-VwB1vAXWaN6mVl3-6JVFTEvf7acguaFDUxsP9UzRkE]",

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -87,7 +87,7 @@ func TestIngressTranslator(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -153,7 +153,7 @@ func TestIngressTranslator(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -229,7 +229,7 @@ func TestIngressTranslator(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -304,7 +304,7 @@ func TestIngressTranslator(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 			vHostsRedirect := []*route.VirtualHost{
@@ -325,7 +325,7 @@ func TestIngressTranslator(t *testing.T) {
 						}},
 						"/test"),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -402,7 +402,7 @@ func TestIngressTranslator(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -526,7 +526,7 @@ func TestIngressTranslator(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -603,7 +603,7 @@ func TestIngressTranslator(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -664,7 +664,7 @@ func TestIngressTranslator(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -726,7 +726,7 @@ func TestIngressTranslator(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -864,7 +864,7 @@ func TestIngressTranslatorWithHTTPOptionDisabled(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 			return &translatedIngress{
@@ -940,7 +940,7 @@ func TestIngressTranslatorWithHTTPOptionDisabled(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"rewritten.example.com"),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -1053,7 +1053,7 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						""),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -1128,7 +1128,7 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						""),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -1204,7 +1204,7 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						""),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -1280,7 +1280,7 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						""),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -1347,7 +1347,7 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						""),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -1418,7 +1418,7 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						""),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 
@@ -1558,8 +1558,8 @@ func TestIngressTranslatorHTTP01Challenge(t *testing.T) {
 						nil,
 						""),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
-					route.WithExtAuthz(map[string]string{"client": "kourier", "visibility": "ExternalIP"}),
+					envoy.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithExtAuthz(map[string]string{"client": "kourier", "visibility": "ExternalIP"}),
 				),
 			}
 
@@ -1672,7 +1672,7 @@ func TestIngressTranslatorDomainMappingDisableHTTP2(t *testing.T) {
 						map[string]string{"foo": "bar"},
 						"bar.default.svc.cluster.local"),
 					},
-					route.WithRetryOnTransientUpstreamFailure(),
+					envoy.WithRetryOnTransientUpstreamFailure(),
 				),
 			}
 


### PR DESCRIPTION
# Changes

- :gift: Add RetryPolicy on VirtualHost for upstream transient connection issues 

/kind enhancement

---

For context, we are operating kourier "at scale":

- thousands of knative services
- hundreds of requests/second
- a lot of activity with new ksvc created, updated, deleted continuously

In the gateway access logs, we sometimes see clients requests ending up in 503. These 503 are always mostly accompanied by `UC` response flag, meaning (from the [docs](https://www.envoyproxy.io/docs/envoy/v1.26.8/configuration/observability/access_log/usage#command-operators)):

> Upstream connection termination in addition to 503 response code.

Connections can be terminated for many reasons, but most of the time, these are linked to transient TCP failures (connect timeout, reset, disconnect, etc.). As of now, the only way to deal with these 503 UC errors is to retry on the caller side, which is not really convenient - and not always possible - for callers.

In order to increase robustness and handle these specific transient cases, Envoy allows setting retry policies at [`VirtualHost` level](https://www.envoyproxy.io/docs/envoy/v1.26.8/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-virtualhost-retry-policy) and/or [`Route` level](https://www.envoyproxy.io/docs/envoy/v1.26.8/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routeaction-retry-policy). By default, these retry policies are **not** configured by Kourier, so this is why Envoy throws directly 503s to the caller, sadly.

This PR configures the `RetryPolicy` at the `VirtualHost` level (because every VH has multiple routes, it would be cumbersome to define it on every route). The conditions to retry, as explained in [Envoy docs](https://www.envoyproxy.io/docs/envoy/v1.26.8/configuration/http/http_filters/router_filter#config-http-filters-router-x-envoy-retry-on), covers all transient upstream connection failures:

> - `reset`: Envoy will attempt a retry if the upstream server does not respond at all (disconnect/reset/read timeout.)
> - `connect-failure`: Envoy will attempt a retry if a request is failed because of a connection failure to the upstream server (connect timeout, etc.). [...] NOTE: A connection failure/timeout is a the TCP level, not the request level

_Note 1_: BTW, this is also what istio seems to do by default: https://istio.io/latest/docs/concepts/traffic-management/#retries, https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRetry, but I'm not really familiar with it, so I can just trust the docs and what I find on the web.

_Note 2_: It might be tempting to retry on every upstream errors (e.g. 5xx), but it is probably not a good idea, as "real" 5xx sent by the users applications (in the ksvc) might not be retriable and can cause more harm if retried. Here, we will just focus on TCP connection errors.

---

Regarding the changes made on the PR itself: I'm pretty sure setting the retry policy for **every** `VirtualHost` can't be harmful; but, as I don't know your opinion on this, I've hidden it behind an option (`WithRetryOnTransientUpstreamFailure()`, using option pattern).

For now, the option is always **on** (`pkg/generator/ingress_translator.go`), but if you prefer, I can easily make it configurable through Kourier configmap (e.g. if `retry-on-upstream-transient-failures: true` in the config, call the option; otherwise, bypass it). When adding this option, I have also changed `NewVirtualHostWithExtAuthz`, because I didn't want to add `if`s everywhere, and managing this with options is far more convenient.

So, from there, there are 2 paths I can take:

1. configure the retry by default: in that case, I can completely remove the "options" pattern, and just configure the `RetryPolicy` in `NewVirtualHost` method (and `NewVirtualHostWithExtAuthz`, by extension)
2. make the retry configurable by the user: in that case, I will keep the "options" pattern, but I will need to change `translateIngress` signature (and all methods calling it) to include the `WithRetryOnTransientUpstreamFailure()` option only if the user have opted-in in kourier config

Solution 1 is easier to implement but does not guarantee side-effects (just adding retries in case of TCP connection issues should be fine though...), while solution 2 allows to be more configurable and retry can stay disabled by default.

Tell me what you think. Thanks :pray:

**Release Note**

```release-note
Add retry policy on every virtual host for upstream transient connection issues
```

**Docs**

N/A