### PR TITLE
Upgrade to distroless envoy

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -25,8 +25,6 @@ jobs:
 
         gateway:
         - quay.io/maistra-dev/proxyv2-ubi8:2.4-latest
-        - docker.io/envoyproxy/envoy:distroless-v1.26-latest
-        - docker.io/envoyproxy/envoy:distroless-v1.27-latest
         - docker.io/envoyproxy/envoy:distroless-v1.28-latest
         - docker.io/envoyproxy/envoy:distroless-v1.29-latest
         - docker.io/envoyproxy/envoy:distroless-v1.30-latest

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -25,9 +25,12 @@ jobs:
 
         gateway:
         - quay.io/maistra-dev/proxyv2-ubi8:2.4-latest
-        - docker.io/envoyproxy/envoy:v1.26-latest
-        - docker.io/envoyproxy/envoy:v1.27-latest
-        - docker.io/envoyproxy/envoy:v1.28-latest
+        - docker.io/envoyproxy/envoy:distroless-v1.26-latest
+        - docker.io/envoyproxy/envoy:distroless-v1.27-latest
+        - docker.io/envoyproxy/envoy:distroless-v1.28-latest
+        - docker.io/envoyproxy/envoy:distroless-v1.29-latest
+        - docker.io/envoyproxy/envoy:distroless-v1.30-latest
+        - docker.io/envoyproxy/envoy:distroless-v1.31-latest
 
         upstream-tls:
         - plain

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -55,7 +55,7 @@ spec:
           env:
             - name: DRAIN_TIME_SECONDS
               value: "15"
-          image: docker.io/envoyproxy/envoy:v1.26-latest
+          image: docker.io/envoyproxy/envoy:distroless-v1.31-latest
           name: kourier-gateway
           ports:
             - name: http2-external


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

Upgrade envoy to `distroless-v1.27` for less vulnerabilities. 

```
grype docker.io/envoyproxy/envoy:distroless-v1.27-latest
 ✔ Vulnerability DB                [no update available]  
 ✔ Loaded image                                                                                                                                                                     index.docker.io/envoyproxy/envoy:distroless-v1.27-latest
 ✔ Parsed image                                                                                                                                                      sha256:f41d403a28eef76aea46c78f4445851a097483bc0a87d1e21ff4bf339494b5dc
 ✔ Cataloged contents                                                                                                                                                       ee5d42d10f744ff27bdc90decf1c21cc195f467815f71bbc8f0a5b271aef25b0
   ├── ✔ Packages                        [4 packages]  
   ├── ✔ File digests                    [1,219 files]  
   ├── ✔ File metadata                   [1,219 locations]  
   └── ✔ Executables                     [274 executables]  
 ✔ Scanned for vulnerabilities     [7 vulnerability matches]  
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 7 negligible
   └── by status:   0 fixed, 7 not-fixed, 0 ignored 
NAME   INSTALLED       FIXED-IN  TYPE  VULNERABILITY     SEVERITY   
libc6  2.36-9+deb12u7            deb   CVE-2019-9192     Negligible  
libc6  2.36-9+deb12u7            deb   CVE-2019-1010025  Negligible  
libc6  2.36-9+deb12u7            deb   CVE-2019-1010024  Negligible  
libc6  2.36-9+deb12u7            deb   CVE-2019-1010023  Negligible  
libc6  2.36-9+deb12u7            deb   CVE-2019-1010022  Negligible  
libc6  2.36-9+deb12u7            deb   CVE-2018-20796    Negligible  
libc6  2.36-9+deb12u7            deb   CVE-2010-4756     Negligible
````

Old envoy container.

```
$ grype docker.io/envoyproxy/envoy:v1.26-latest
 ✔ Vulnerability DB                [no update available]  
 ✔ Loaded image                                                                                                                                                                                index.docker.io/envoyproxy/envoy:v1.26-latest
 ✔ Parsed image                                                                                                                                                      sha256:f63d21feeb3ca857a72182892c6c14fd8ed75dc3871c57f4578b342e1409b64d
 ✔ Cataloged contents                                                                                                                                                       264d816f68880c01a3daf9ec3b56e15723ddc0e952e8c623f42a2149ddae9c3f
   ├── ✔ Packages                        [95 packages]  
   ├── ✔ File digests                    [2,127 files]  
   ├── ✔ File metadata                   [2,127 locations]  
   └── ✔ Executables                     [734 executables]  
 ✔ Scanned for vulnerabilities     [47 vulnerability matches]  
   ├── by severity: 0 critical, 0 high, 16 medium, 28 low, 3 negligible
   └── by status:   11 fixed, 36 not-fixed, 0 ignored 
NAME          INSTALLED                 FIXED-IN            TYPE  VULNERABILITY   SEVERITY   
coreutils     8.30-3ubuntu2                                 deb   CVE-2016-2781   Low         
gcc-10-base   10.5.0-1ubuntu1~20.04                         deb   CVE-2023-4039   Medium      
gpgv          2.2.19-3ubuntu2.2                             deb   CVE-2022-3219   Low         
libc-bin      2.31-0ubuntu9.14          2.31-0ubuntu9.16    deb   CVE-2024-33602  Medium      
libc-bin      2.31-0ubuntu9.14          2.31-0ubuntu9.16    deb   CVE-2024-33601  Medium      
libc-bin      2.31-0ubuntu9.14          2.31-0ubuntu9.16    deb   CVE-2024-33600  Medium      
libc-bin      2.31-0ubuntu9.14          2.31-0ubuntu9.16    deb   CVE-2024-33599  Medium      
libc-bin      2.31-0ubuntu9.14          2.31-0ubuntu9.15    deb   CVE-2024-2961   Medium      
libc-bin      2.31-0ubuntu9.14                              deb   CVE-2016-20013  Negligible  
libc6         2.31-0ubuntu9.14          2.31-0ubuntu9.16    deb   CVE-2024-33602  Medium      
libc6         2.31-0ubuntu9.14          2.31-0ubuntu9.16    deb   CVE-2024-33601  Medium      
libc6         2.31-0ubuntu9.14          2.31-0ubuntu9.16    deb   CVE-2024-33600  Medium      
libc6         2.31-0ubuntu9.14          2.31-0ubuntu9.16    deb   CVE-2024-33599  Medium      
libc6         2.31-0ubuntu9.14          2.31-0ubuntu9.15    deb   CVE-2024-2961   Medium      
libc6         2.31-0ubuntu9.14                              deb   CVE-2016-20013  Negligible  
libgcc-s1     10.5.0-1ubuntu1~20.04                         deb   CVE-2023-4039   Medium      
libgcrypt20   1.8.5-5ubuntu1.1                              deb   CVE-2024-2236   Medium      
libgnutls30   3.6.13-2ubuntu1.10        3.6.13-2ubuntu1.11  deb   CVE-2024-28834  Medium      
liblzma5      5.2.4-1ubuntu1.1                              deb   CVE-2020-22916  Medium      
libncurses6   6.2-0ubuntu2.1                                deb   CVE-2023-50495  Low         
libncurses6   6.2-0ubuntu2.1                                deb   CVE-2023-45918  Low         
libncursesw6  6.2-0ubuntu2.1                                deb   CVE-2023-50495  Low         
libncursesw6  6.2-0ubuntu2.1                                deb   CVE-2023-45918  Low         
libpcre2-8-0  10.34-7ubuntu0.1                              deb   CVE-2022-41409  Low         
libpcre3      2:8.39-12ubuntu0.1                            deb   CVE-2017-11164  Negligible  
libssl1.1     1.1.1f-1ubuntu2.22                            deb   CVE-2024-5535   Low         
libssl1.1     1.1.1f-1ubuntu2.22                            deb   CVE-2024-4741   Low         
libssl1.1     1.1.1f-1ubuntu2.22                            deb   CVE-2024-2511   Low         
libstdc++6    10.5.0-1ubuntu1~20.04                         deb   CVE-2023-4039   Medium      
libsystemd0   245.4-4ubuntu3.23                             deb   CVE-2023-7008   Low         
libsystemd0   245.4-4ubuntu3.23                             deb   CVE-2023-26604  Low         
libtasn1-6    4.16.0-2                                      deb   CVE-2021-46848  Low         
libtinfo6     6.2-0ubuntu2.1                                deb   CVE-2023-50495  Low         
libtinfo6     6.2-0ubuntu2.1                                deb   CVE-2023-45918  Low         
libudev1      245.4-4ubuntu3.23                             deb   CVE-2023-7008   Low         
libudev1      245.4-4ubuntu3.23                             deb   CVE-2023-26604  Low         
login         1:4.8.1-1ubuntu5.20.04.5                      deb   CVE-2023-29383  Low         
login         1:4.8.1-1ubuntu5.20.04.5                      deb   CVE-2013-4235   Low         
ncurses-base  6.2-0ubuntu2.1                                deb   CVE-2023-50495  Low         
ncurses-base  6.2-0ubuntu2.1                                deb   CVE-2023-45918  Low         
ncurses-bin   6.2-0ubuntu2.1                                deb   CVE-2023-50495  Low         
ncurses-bin   6.2-0ubuntu2.1                                deb   CVE-2023-45918  Low         
openssl       1.1.1f-1ubuntu2.22                            deb   CVE-2024-5535   Low         
openssl       1.1.1f-1ubuntu2.22                            deb   CVE-2024-4741   Low         
openssl       1.1.1f-1ubuntu2.22                            deb   CVE-2024-2511   Low         
passwd        1:4.8.1-1ubuntu5.20.04.5                      deb   CVE-2023-29383  Low         
passwd        1:4.8.1-1ubuntu5.20.04.5                      deb   CVE-2013-4235   Low
```

/kind enhancement

