### PR TITLE
Bump envoy version and use shared go version

### DIFF
--- a/.github/workflows/kind-e2e-upgrade.yaml
+++ b/.github/workflows/kind-e2e-upgrade.yaml
@@ -36,10 +36,8 @@ jobs:
       KIND_CLUSTER_NAME: "kourier-integration"
 
     steps:
-    - name: Set up Go 1.21.x
-      uses: actions/setup-go@v4
-      with:
-        go-version: 1.21.x
+    - name: setup-go
+      uses: knative/actions/setup-go@main
 
     - uses: ko-build/setup-ko@v0.6
 

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -25,9 +25,10 @@ jobs:
 
         gateway:
         - quay.io/maistra-dev/proxyv2-ubi8:2.4-latest
-        - docker.io/envoyproxy/envoy:v1.26-latest
-        - docker.io/envoyproxy/envoy:v1.27-latest
         - docker.io/envoyproxy/envoy:v1.28-latest
+        - docker.io/envoyproxy/envoy:v1.29-latest
+        - docker.io/envoyproxy/envoy:v1.30-latest
+        - docker.io/envoyproxy/envoy:v1.31-latest
 
         upstream-tls:
         - plain
@@ -41,10 +42,8 @@ jobs:
       CLUSTER_SUFFIX: c${{ github.run_id }}.local
 
     steps:
-    - name: Set up Go 1.21.x
-      uses: actions/setup-go@v4
-      with:
-        go-version: 1.21.x
+    - name: setup-go
+      uses: knative/actions/setup-go@main
 
     - uses: ko-build/setup-ko@v0.6
 

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -55,7 +55,7 @@ spec:
           env:
             - name: DRAIN_TIME_SECONDS
               value: "15"
-          image: docker.io/envoyproxy/envoy:v1.26-latest
+          image: docker.io/envoyproxy/envoy:v1.31-latest
           name: kourier-gateway
           ports:
             - name: http2-external


### PR DESCRIPTION
# Changes
- As per https://github.com/knative-extensions/net-kourier/pull/1271#issuecomment-2355081046
- Bumps envoy versions
- Uses shared go setup action to have aligned versions

**Release Note**

```release-note
`net-kourier` now uses envoy in version 1.31
```

/assign @skonto let's see if we can go with 1.31 as default or not.


