### PR TITLE
Allow to disable envoy server header injection

### DIFF
--- a/config/200-config.yaml
+++ b/config/200-config.yaml
@@ -80,3 +80,6 @@ data:
     # Use ',' separated values like "ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-ECDSA-CHACHA20-POLY1305"
     # The default uses the default cipher suites of the envoy version.
     cipher-suites: ""
+
+    # Disable the Envoy server header injection in the response when response has no such header.
+    disable-envoy-server-header: "false"

--- a/pkg/config/configmap.go
+++ b/pkg/config/configmap.go
@@ -52,6 +52,8 @@ const (
 
 	// TracingCollectorFullEndpoint is the config map key to configure tracing at kourier gateway level
 	TracingCollectorFullEndpoint = "tracing-collector-full-endpoint"
+
+	disableEnvoyServerHeader = "disable-envoy-server-header"
 )
 
 func DefaultConfig() *Kourier {
@@ -64,6 +66,7 @@ func DefaultConfig() *Kourier {
 		CipherSuites:               nil,
 		EnableCryptoMB:             false,
 		UseRemoteAddress:           false,
+		DisableEnvoyServerHeader:   false,
 	}
 }
 
@@ -81,6 +84,7 @@ func NewConfigFromMap(configMap map[string]string) (*Kourier, error) {
 		cm.AsStringSet(cipherSuites, &nc.CipherSuites),
 		cm.AsBool(enableCryptoMB, &nc.EnableCryptoMB),
 		asTracing(TracingCollectorFullEndpoint, &nc.Tracing),
+		cm.AsBool(disableEnvoyServerHeader, &nc.DisableEnvoyServerHeader),
 	); err != nil {
 		return nil, err
 	}
@@ -161,4 +165,6 @@ type Kourier struct {
 	CipherSuites sets.Set[string]
 	// Tracing specifies the configuration for gateway tracing
 	Tracing Tracing
+	// Disable Server Header
+	DisableEnvoyServerHeader bool
 }

--- a/pkg/envoy/api/http_connection_manager.go
+++ b/pkg/envoy/api/http_connection_manager.go
@@ -52,6 +52,7 @@ func NewHTTPConnectionManager(routeConfigName string, kourierConfig *config.Kour
 	})
 	enableAccessLog := kourierConfig.EnableServiceAccessLogging
 	enableProxyProtocol := kourierConfig.EnableProxyProtocol
+	disableEnvoyServerHeader := kourierConfig.DisableEnvoyServerHeader
 	idleTimeout := kourierConfig.IdleTimeout
 
 	mgr := &hcm.HttpConnectionManager{
@@ -78,6 +79,11 @@ func NewHTTPConnectionManager(routeConfigName string, kourierConfig *config.Kour
 	if enableProxyProtocol {
 		//Force the connection manager to use the real remote address of the client connection.
 		mgr.UseRemoteAddress = &wrapperspb.BoolValue{Value: true}
+	}
+
+	if disableEnvoyServerHeader {
+		//Force the connection manager to skip envoy's server header if none is present
+		mgr.ServerHeaderTransformation = hcm.HttpConnectionManager_PASS_THROUGH
 	}
 
 	if enableAccessLog {

--- a/pkg/envoy/api/http_connection_manager_test.go
+++ b/pkg/envoy/api/http_connection_manager_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package envoy
 
 import (
-	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"math"
 	"testing"
 	"time"
@@ -25,6 +24,7 @@ import (
 	envoy_config_filter_accesslog_v3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	fileaccesslog "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
+	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/anypb"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Downstream users want to hide the [server header](https://security.stackexchange.com/questions/23256/what-is-the-http-server-response-header-field-used-for). If there is no such header present in the response, by default Envoy injects its own that has the value `envoy` (based on the default server_name config). Envoy allows to configure when the server header is injected. Here we support only the option to prevent Envoy's header injection. In a secured environment probably this should be on by default.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
A new configuration option `disable-envoy-server-header` prevents Envoy server header from being injected when there is none such header in the response.
```
