### PR TITLE
fix(config): Update the controller DNS in bootstrap

### DIFF
--- a/config/200-bootstrap.yaml
+++ b/config/200-bootstrap.yaml
@@ -113,7 +113,7 @@ data:
                 endpoint:
                   address:
                     socket_address:
-                      address: "net-kourier-controller.knative-serving"
+                      address: "net-kourier-controller"
                       port_value: 18000
           type: STRICT_DNS
     admin:


### PR DESCRIPTION
# Changes

Update the controller DNS name to use the short form of the DNS that should be resolvable within the namespace as all components involved should be in the same namespace.

/kind bug

This fixes issues if deployed outside of `knative-serving` namespace (via the operator etc.) as the original is hardcoded with that namespace.  As in that case the gateways will never become healthy as they cannot communicate with the incorrect address in this configuration.  The short form change here should be functional in all cases.

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Fix hardcoded namespace in DNS for kourier controller in envoy bootstrap
```
