### PR TITLE
Refactor e2e-kind.sh to use rollout status instead of condition check

### DIFF
--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -110,7 +110,7 @@ kubectl -n "${KOURIER_CONTROL_NAMESPACE}" patch configmap/config-kourier --type 
     "extauthz-protocol": "grpc"
   }
 }'
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout restart -n knative-serving deployment/net-kourier-controller
+kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout restart deployment/net-kourier-controller
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller --timeout=300s
 
 echo ">> Running ExtAuthz tests"
@@ -124,7 +124,7 @@ kubectl -n "${KOURIER_CONTROL_NAMESPACE}" patch configmaps/config-kourier --type
   {"op":"remove","path":"/data/extauthz-host"},
   {"op":"remove","path":"/data/extauthz-protocol"}
 ]'
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout restart -n knative-serving deployment/net-kourier-controller
+kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout restart deployment/net-kourier-controller
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller
 
 echo ">> Setup ExtAuthz gRPC with pack as bytes option"
@@ -152,7 +152,7 @@ kubectl -n "${KOURIER_CONTROL_NAMESPACE}" patch configmap/config-kourier --type 
     "extauthz-pack-as-bytes": "true"
   }
 }'
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout restart -n knative-serving deployment/net-kourier-controller
+kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout restart deployment/net-kourier-controller
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller --timeout=300s
 
 echo ">> Running ExtAuthz tests"
@@ -167,7 +167,7 @@ kubectl -n "${KOURIER_CONTROL_NAMESPACE}" patch configmaps/config-kourier --type
   {"op":"remove","path":"/data/extauthz-protocol"},
   {"op":"remove","path":"/data/extauthz-pack-as-bytes"}
 ]'
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout restart -n knative-serving deployment/net-kourier-controller
+kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout restart deployment/net-kourier-controller
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller
 
 echo ">> Setup ExtAuthz HTTP"
@@ -195,7 +195,7 @@ kubectl -n "${KOURIER_CONTROL_NAMESPACE}" patch configmap/config-kourier --type 
     "extauthz-protocol": "http"
   }
 }'
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout restart -n knative-serving deployment/net-kourier-controller
+kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout restart deployment/net-kourier-controller
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller --timeout=300s
 
 echo ">> Running ExtAuthz tests"
@@ -209,12 +209,12 @@ kubectl -n "${KOURIER_CONTROL_NAMESPACE}" patch configmaps/config-kourier --type
   {"op":"remove","path":"/data/extauthz-host"},
   {"op":"remove","path":"/data/extauthz-protocol"}
 ]'
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout restart -n knative-serving deployment/net-kourier-controller
+kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout restart deployment/net-kourier-controller
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller
 
 echo ">> Setup ExtAuthz HTTP with path prefix"
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment externalauthz-http PATH_PREFIX="/check"
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" wait --timeout=300s --for=condition=Available deployment/externalauthz-http
+kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/externalauthz-http
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment net-kourier-controller \
   KOURIER_EXTAUTHZ_HOST=externalauthz-http.knative-serving:8080 \
   KOURIER_EXTAUTHZ_PROTOCOL=http \
@@ -239,7 +239,7 @@ kubectl -n "${KOURIER_CONTROL_NAMESPACE}" patch configmap/config-kourier --type 
     "extauthz-path-prefix": "/check"
   }
 }'
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout restart -n knative-serving deployment/net-kourier-controller
+kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout restart deployment/net-kourier-controller
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller --timeout=300s
 
 echo ">> Running ExtAuthz tests"
@@ -254,7 +254,7 @@ kubectl -n "${KOURIER_CONTROL_NAMESPACE}" patch configmaps/config-kourier --type
   {"op":"remove","path":"/data/extauthz-protocol"},
   {"op":"remove","path":"/data/extauthz-path-prefix"}
 ]'
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout restart -n knative-serving deployment/net-kourier-controller
+kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout restart deployment/net-kourier-controller
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller
 
 echo ">> Setup Proxy Protocol"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

:bug: Refactoring performed on e2e-kind.sh:
- 1: Removed unnecessary namespace specification.
  - This should have been fixed in https://github.com/knative-extensions/net-kourier/pull/1334 🙇 
- 2: Modified to reference rollout status instead of condition.


Regarding point 2:

We are experiencing intermittent failures with GitHub Actions.
- https://github.com/knative-extensions/net-kourier/actions/runs/15393564244/job/43308474380
- https://github.com/knative-extensions/net-kourier/actions/runs/15344106223/job/43176455027

From what I’ve observed, the following behaviour occurs:
- GitHub Actions fail during tests that configure path prefixes.
- Until the path prefix configuration is reflected in the Pod (externalAuthz), a 403 error occurs.

The `condition=Available` check likely doesn't guarantee that the pod has completed its rollout.
Therefore, I have modified the configuration to verify the rollout status instead.


<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

