### PR TITLE
Refactor: Use config embedded in context

### DIFF
--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -26,13 +26,13 @@ import (
 
 // UpdateInfoForIngress translates an Ingress into envoy configuration and updates the
 // respective caches.
-func UpdateInfoForIngress(ctx context.Context, caches *Caches, ing *v1alpha1.Ingress, translator *IngressTranslator, extAuthzEnabled bool) error {
+func UpdateInfoForIngress(ctx context.Context, caches *Caches, ing *v1alpha1.Ingress, translator *IngressTranslator) error {
 	// Adds a header with the ingress Hash and a random value header to force the config reload.
 	if _, err := ingress.InsertProbe(ing); err != nil {
 		return fmt.Errorf("failed to add knative probe header: %w", err)
 	}
 
-	ingressTranslation, err := translator.translateIngress(ctx, ing, extAuthzEnabled)
+	ingressTranslation, err := translator.translateIngress(ctx, ing)
 	if err != nil {
 		return fmt.Errorf("failed to translate ingress: %w", err)
 	}

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -784,7 +784,7 @@ func TestIngressTranslator(t *testing.T) {
 
 			translator := newTestIngressTranslator(ctx, kubeclient)
 
-			got, err := translator.translateIngress(ctx, test.in, false)
+			got, err := translator.translateIngress(ctx, test.in)
 			assert.Equal(t, err != nil, test.wantErr)
 			assert.DeepEqual(t, got, test.want,
 				cmp.AllowUnexported(translatedIngress{}),
@@ -987,7 +987,7 @@ func TestIngressTranslatorWithHTTPOptionDisabled(t *testing.T) {
 
 			translator := newTestIngressTranslator(ctx, kubeclient)
 
-			got, err := translator.translateIngress(ctx, test.in, false)
+			got, err := translator.translateIngress(ctx, test.in)
 			assert.NilError(t, err)
 			assert.DeepEqual(t, got, test.want,
 				cmp.AllowUnexported(translatedIngress{}),
@@ -1480,7 +1480,7 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 
 			translator := newTestIngressTranslator(ctx, kubeclient)
 
-			got, err := translator.translateIngress(ctx, test.in, false)
+			got, err := translator.translateIngress(ctx, test.in)
 			assert.Equal(t, err != nil, test.wantErr)
 			assert.DeepEqual(t, got, test.want,
 				cmp.AllowUnexported(translatedIngress{}),
@@ -1566,13 +1566,14 @@ func TestIngressTranslatorHTTP01Challenge(t *testing.T) {
 	t.Run(test.name, func(t *testing.T) {
 		ctx, _ := pkgtest.SetupFakeContext(t)
 		cfg := defaultConfig.DeepCopy()
+		cfg.Kourier.ExternalAuthz.Enabled = true
 		ctx = (&testConfigStore{config: cfg}).ToContext(ctx)
 
 		kubeclient := fake.NewSimpleClientset(test.state...)
 
 		translator := newTestIngressTranslator(ctx, kubeclient)
 
-		got, err := translator.translateIngress(ctx, test.in, true)
+		got, err := translator.translateIngress(ctx, test.in)
 
 		assert.NilError(t, err)
 		assert.DeepEqual(t, got, test.want,
@@ -1672,7 +1673,7 @@ func TestIngressTranslatorDomainMappingDisableHTTP2(t *testing.T) {
 
 		translator := newTestIngressTranslator(ctx, kubeclient)
 
-		got, err := translator.translateIngress(ctx, test.in, false)
+		got, err := translator.translateIngress(ctx, test.in)
 		assert.NilError(t, err)
 		assert.DeepEqual(t, got, test.want,
 			cmp.AllowUnexported(translatedIngress{}),
@@ -2144,7 +2145,7 @@ func TestTranslateIngress_EndpointsNotReady(t *testing.T) {
 		&pkgtest.FakeTracker{})
 
 	// Translate the ingress
-	result, err := translator.translateIngress(ctx, ingress, false)
+	result, err := translator.translateIngress(ctx, ingress)
 	// Should return nil, nil when endpoints are not ready
 	if err != nil {
 		t.Errorf("Expected nil error, got %v", err)
@@ -2231,7 +2232,7 @@ func TestTranslateIngressWithDuplicateDomains(t *testing.T) {
 		},
 		&pkgtest.FakeTracker{})
 
-	result, err := translator.translateIngress(ctx, ingress, false)
+	result, err := translator.translateIngress(ctx, ingress)
 	if err != nil {
 		t.Fatalf("translateIngress() error = %v", err)
 	}
@@ -2355,7 +2356,7 @@ func TestTranslateIngressWithMultipleDomainsAndPaths(t *testing.T) {
 		},
 		&pkgtest.FakeTracker{})
 
-	result, err := translator.translateIngress(ctx, ingress, false)
+	result, err := translator.translateIngress(ctx, ingress)
 	if err != nil {
 		t.Fatalf("translateIngress() error = %v", err)
 	}
@@ -2471,7 +2472,7 @@ func TestTranslateIngressWithMixedVisibility(t *testing.T) {
 		},
 		&pkgtest.FakeTracker{})
 
-	result, err := translator.translateIngress(ctx, ingress, false)
+	result, err := translator.translateIngress(ctx, ingress)
 	if err != nil {
 		t.Fatalf("translateIngress() error = %v", err)
 	}

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -98,8 +98,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	}
 
 	r := &Reconciler{
-		caches:   caches,
-		extAuthz: config.FromContext(ctx).Kourier.ExternalAuthz.Enabled,
+		caches: caches,
 	}
 
 	impl := v1alpha1ingress.NewImpl(ctx, r, config.KourierIngressClassName, func(impl *controller.Impl) controller.Options {
@@ -264,7 +263,8 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 	for _, ingress := range ingressesToSync {
 		if err := generator.UpdateInfoForIngress(
-			ctx, caches, ingress, &startupTranslator, config.FromContext(ctx).Kourier.ExternalAuthz.Enabled); err != nil {
+			ctx, caches, ingress, &startupTranslator,
+		); err != nil {
 			logger.Fatalw("Failed prewarm ingress", zap.Error(err))
 		}
 	}

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -42,7 +42,6 @@ type Reconciler struct {
 	caches            *generator.Caches
 	statusManager     *status.Prober
 	ingressTranslator *generator.IngressTranslator
-	extAuthz          bool
 
 	// resyncConflicts triggers a filtered global resync to reenqueue all ingresses in
 	// a "Conflict" state.
@@ -148,7 +147,7 @@ func (r *Reconciler) updateIngress(ctx context.Context, ingress *v1alpha1.Ingres
 	logger.Infof("Updating Ingress")
 
 	if err := generator.UpdateInfoForIngress(
-		ctx, r.caches, ingress, r.ingressTranslator, r.extAuthz); err != nil {
+		ctx, r.caches, ingress, r.ingressTranslator); err != nil {
 		return err
 	}
 

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -166,7 +166,6 @@ func TestReconcile(t *testing.T) {
 			xdsServer:         server.NewXdsServer(18000, &xds.CallbackFuncs{}),
 			caches:            c,
 			ingressTranslator: &it,
-			extAuthz:          false,
 			resyncConflicts:   func() {},
 			statusManager: status.NewProber(
 				nil, NewProbeTargetLister(logging.FromContext(ctx), ls.GetEndpointSlicesLister()), nil,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Removed the extAuthz field in Reconciler, instead utilizing the Config.Kourier.ExternalAuthz embedded within the context.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind cleanup
