### PR TITLE
Added support to configure listener ip addresses with comma separated list of IPs (ex: "0.0.0.0,::")

### DIFF
--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -236,11 +236,11 @@ func generateListenersAndRouteConfigsAndClusters(
 	externalTLSManager := envoy.NewHTTPConnectionManager(externalTLSRouteConfig.GetName(), cfg.Kourier)
 	localManager := envoy.NewHTTPConnectionManager(localRouteConfig.GetName(), cfg.Kourier)
 
-	externalHTTPEnvoyListener, err := envoy.NewHTTPListener(externalManager, config.HTTPPortExternal, cfg.Kourier.EnableProxyProtocol)
+	externalHTTPEnvoyListener, err := envoy.NewHTTPListener(externalManager, config.HTTPPortExternal, cfg.Kourier.EnableProxyProtocol, cfg.Kourier.ListenIPAddresses)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	localEnvoyListener, err := envoy.NewHTTPListener(localManager, config.HTTPPortLocal, false)
+	localEnvoyListener, err := envoy.NewHTTPListener(localManager, config.HTTPPortLocal, false, cfg.Kourier.ListenIPAddresses)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -250,7 +250,7 @@ func generateListenersAndRouteConfigsAndClusters(
 	clusters := make([]cachetypes.Resource, 0, 1)
 
 	// create probe listeners
-	probHTTPListener, err := envoy.NewHTTPListener(externalManager, config.HTTPPortProb, false)
+	probHTTPListener, err := envoy.NewHTTPListener(externalManager, config.HTTPPortProb, false, cfg.Kourier.ListenIPAddresses)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -367,7 +367,7 @@ func generateListenersAndRouteConfigsAndClusters(
 		}
 
 		// create https prob listener
-		probHTTPSListener, err := envoy.NewHTTPSListener(config.HTTPSPortProb, externalHTTPSEnvoyListener.GetFilterChains(), false)
+		probHTTPSListener, err := envoy.NewHTTPSListener(config.HTTPSPortProb, externalHTTPSEnvoyListener.GetFilterChains(), false, cfg.Kourier.ListenIPAddresses)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -442,7 +442,7 @@ func newExternalEnvoyListenerWithOneCert(ctx context.Context, manager *httpconnm
 		return nil, err
 	}
 
-	return envoy.NewHTTPSListener(config.HTTPSPortExternal, []*v3.FilterChain{filterChain}, cfg.EnableProxyProtocol)
+	return envoy.NewHTTPSListener(config.HTTPSPortExternal, []*v3.FilterChain{filterChain}, cfg.EnableProxyProtocol, cfg.ListenIPAddresses)
 }
 
 func newLocalEnvoyListenerWithOneCertFilterChain(ctx context.Context, manager *httpconnmanagerv3.HttpConnectionManager, kubeClient kubeclient.Interface, cfg *config.Kourier) (*v3.FilterChain, error) {
@@ -463,7 +463,7 @@ func newLocalEnvoyListenerWithOneCert(ctx context.Context, manager *httpconnmana
 	if err != nil {
 		return nil, err
 	}
-	return envoy.NewHTTPSListener(config.HTTPSPortLocal, []*v3.FilterChain{filterChain}, cfg.EnableProxyProtocol)
+	return envoy.NewHTTPSListener(config.HTTPSPortLocal, []*v3.FilterChain{filterChain}, cfg.EnableProxyProtocol, cfg.ListenIPAddresses)
 }
 
 func privateKeyProvider(mbEnabled bool) string {

--- a/pkg/generator/caches_test.go
+++ b/pkg/generator/caches_test.go
@@ -283,6 +283,7 @@ func TestLocalTLSListener(t *testing.T) {
 	testConfig := &config.Config{
 		Network: &netconfig.Config{},
 		Kourier: &config.Kourier{
+			ListenIPAddresses:   []string{"0.0.0.0"},
 			ClusterCertSecret:   "test-ca",
 			EnableProxyProtocol: true,
 		},
@@ -396,6 +397,7 @@ func TestLocalTLSListener(t *testing.T) {
 func TestListenersAndClustersWithTracing(t *testing.T) {
 	testConfig := &config.Config{
 		Kourier: &config.Kourier{
+			ListenIPAddresses: []string{"0.0.0.0"},
 			Tracing: config.Tracing{
 				Enabled:           true,
 				CollectorHost:     "jaeger.default.svc.cluster.local",

--- a/pkg/reconciler/ingress/config/kourier.go
+++ b/pkg/reconciler/ingress/config/kourier.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strconv"
 	"time"
+	"strings"
 
 	"github.com/kelseyhightower/envconfig"
 	corev1 "k8s.io/api/core/v1"
@@ -56,6 +57,9 @@ const (
 	// enableCryptoMB is the config map for enabling CryptoMB private key provider.
 	enableCryptoMB = "enable-cryptomb"
 
+        // listenIPAddress receives a the list of IP addresses to listen to.
+	listenIPAddresses = "listen-ip-addresses"
+
 	// TracingCollectorFullEndpoint is the config map key to configure tracing at kourier gateway level
 	TracingCollectorFullEndpoint = "tracing-collector-full-endpoint"
 
@@ -86,6 +90,7 @@ func defaultKourierConfig() *Kourier {
 		TrustedHopsCount:           0,
 		CipherSuites:               nil,
 		EnableCryptoMB:             false,
+		ListenIPAddresses:          []string{"0.0.0.0"},
 		UseRemoteAddress:           false,
 		DisableEnvoyServerHeader:   false,
 		ExternalAuthz: ExternalAuthz{
@@ -111,6 +116,7 @@ func NewKourierConfigFromMap(configMap map[string]string) (*Kourier, error) {
 		cm.AsBool(useRemoteAddress, &nc.UseRemoteAddress),
 		cm.AsStringSet(cipherSuites, &nc.CipherSuites),
 		cm.AsBool(enableCryptoMB, &nc.EnableCryptoMB),
+		AsStringList(listenIPAddresses, &nc.ListenIPAddresses),
 		asTracing(TracingCollectorFullEndpoint, &nc.Tracing),
 		asExternalAuthz(&nc.ExternalAuthz),
 		cm.AsBool(disableEnvoyServerHeader, &nc.DisableEnvoyServerHeader),
@@ -257,6 +263,8 @@ type Kourier struct {
 	// EnableCryptoMB specifies whether Kourier enable CryptoMB private provider to accelerate
 	// TLS handshake. The default value is "false".
 	EnableCryptoMB bool
+	// The main IP address to listen to
+	ListenIPAddresses []string
 	// CipherSuites specifies the cipher suites for TLS external listener.
 	CipherSuites sets.Set[string]
 	// Tracing specifies the configuration for gateway tracing
@@ -275,4 +283,19 @@ type Kourier struct {
 // instead of one per ingress
 func (k *Kourier) UseHTTPSListenerWithOneCert() bool {
 	return k.CertsSecretName != "" && k.CertsSecretNamespace != ""
+}
+
+// AsStringSet parses the value at key as a []string (split by ',') into the target, if it exists.
+// In contrast with AsStringSet it preserves order
+func AsStringList(key string, target *[]string) cm.ParseFunc {
+	return func(data map[string]string) error {
+		if raw, ok := data[key]; ok {
+			splitted := strings.Split(raw, ",")
+			for i, v := range splitted {
+				splitted[i] = strings.TrimSpace(v)
+			}
+			*target = splitted
+		}
+		return nil
+	}
 }

--- a/pkg/reconciler/ingress/config/kourier_test.go
+++ b/pkg/reconciler/ingress/config/kourier_test.go
@@ -41,6 +41,7 @@ func TestKourierConfig(t *testing.T) {
 	}, {
 		name: "disable logging",
 		want: &Kourier{
+			ListenIPAddresses: []string{"0.0.0.0"},
 			EnableServiceAccessLogging: false,
 			IdleTimeout:                0 * time.Second,
 		},
@@ -56,6 +57,7 @@ func TestKourierConfig(t *testing.T) {
 	}, {
 		name: "enable proxy protocol, logging and internal cert",
 		want: &Kourier{
+			ListenIPAddresses: []string{"0.0.0.0"},
 			EnableServiceAccessLogging: true,
 			EnableProxyProtocol:        true,
 			ClusterCertSecret:          "my-cert",
@@ -69,6 +71,7 @@ func TestKourierConfig(t *testing.T) {
 	}, {
 		name: "enable proxy protocol and disable logging, empty internal cert",
 		want: &Kourier{
+			ListenIPAddresses: []string{"0.0.0.0"},
 			EnableServiceAccessLogging: false,
 			EnableProxyProtocol:        true,
 			ClusterCertSecret:          "",
@@ -88,6 +91,7 @@ func TestKourierConfig(t *testing.T) {
 	}, {
 		name: "set cipher suites",
 		want: &Kourier{
+			ListenIPAddresses: []string{"0.0.0.0"},
 			EnableServiceAccessLogging: false,
 			CipherSuites:               sets.New("foo", "bar"),
 		},
@@ -98,6 +102,7 @@ func TestKourierConfig(t *testing.T) {
 	}, {
 		name: "set timeout to 200",
 		want: &Kourier{
+			ListenIPAddresses: []string{"0.0.0.0"},
 			EnableServiceAccessLogging: true,
 			EnableProxyProtocol:        false,
 			ClusterCertSecret:          "",
@@ -112,6 +117,7 @@ func TestKourierConfig(t *testing.T) {
 	}, {
 		name: "add 3 trusted hops",
 		want: &Kourier{
+			ListenIPAddresses: []string{"0.0.0.0"},
 			EnableServiceAccessLogging: false,
 			TrustedHopsCount:           3,
 		},
@@ -122,6 +128,7 @@ func TestKourierConfig(t *testing.T) {
 	}, {
 		name: "configure tracing",
 		want: &Kourier{
+			ListenIPAddresses: []string{"0.0.0.0"},
 			EnableServiceAccessLogging: true,
 			Tracing: Tracing{
 				Enabled:           true,
@@ -136,6 +143,7 @@ func TestKourierConfig(t *testing.T) {
 	}, {
 		name: "do not enable tracing",
 		want: &Kourier{
+			ListenIPAddresses: []string{"0.0.0.0"},
 			EnableServiceAccessLogging: true,
 			Tracing: Tracing{
 				Enabled: false,
@@ -147,6 +155,7 @@ func TestKourierConfig(t *testing.T) {
 	}, {
 		name: "enable use remote address",
 		want: &Kourier{
+			ListenIPAddresses: []string{"0.0.0.0"},
 			EnableServiceAccessLogging: true,
 			UseRemoteAddress:           true,
 		},
@@ -156,6 +165,7 @@ func TestKourierConfig(t *testing.T) {
 	}, {
 		name: "enable use certs",
 		want: &Kourier{
+			ListenIPAddresses: []string{"0.0.0.0"},
 			EnableServiceAccessLogging: true,
 			CertsSecretName:            "cert",
 			CertsSecretNamespace:       "certns",
@@ -167,6 +177,7 @@ func TestKourierConfig(t *testing.T) {
 	}, {
 		name: "enable use certs from env",
 		want: &Kourier{
+			ListenIPAddresses: []string{"0.0.0.0"},
 			EnableServiceAccessLogging: true,
 			CertsSecretName:            "env-cert",
 			CertsSecretNamespace:       "env-certns",
@@ -178,6 +189,7 @@ func TestKourierConfig(t *testing.T) {
 	}, {
 		name: "override when set via configmap",
 		want: &Kourier{
+			ListenIPAddresses: []string{"0.0.0.0"},
 			EnableServiceAccessLogging: true,
 			CertsSecretName:            "cert",
 			CertsSecretNamespace:       "certns",

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -195,7 +195,9 @@ var _ reconciler.ConfigStore = (*testConfigStore)(nil)
 
 func ReconcilerTestConfig() *config.Config {
 	return &config.Config{
-		Kourier: &config.Kourier{},
+		Kourier: &config.Kourier{
+			ListenIPAddresses: []string{"0.0.0.0"},
+		},
 		Network: &netconfig.Config{
 			ExternalDomainTLS: false,
 		},


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Added new configmap param "listen-ip-addresses" to configure the list of IP address to listen to (ex: "0.0.0.0,::") for listening IPv4 and IPv6. Default behaviour is "0.0.0.0" to keep backward compatibility
- Added tests for new functionality
- Modified previous tests to include the new arguments

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1299

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Add ability to set a list of listening IP addresses. This enables the usage of kourier in clusters with IPv4 and IPv6.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
