### PR TITLE
Fix handling of endpoints with no ready addresses

### DIFF
--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -207,6 +207,14 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 
 					typ = v3.Cluster_STATIC
 					publicLbEndpoints = lbEndpointsForKubeEndpoints(endpoints, targetPort)
+
+					// If endpoints exist but have no ready addresses, skip this ingress.
+					// The tracker will trigger reconciliation when endpoints become ready.
+					if len(publicLbEndpoints) == 0 {
+						logger.Warnf("Endpoints '%s/%s' exist but have no ready addresses, skipping ingress translation",
+							split.ServiceNamespace, split.ServiceName)
+						return nil, nil
+					}
 				}
 
 				connectTimeout := 5 * time.Second


### PR DESCRIPTION
When Kourier reconciles an Ingress with endpoints that have no ready addresses, it creates Envoy clusters with empty endpoints [{}], which Envoy rejects, triggering an error loop.

The issue occurs because lbEndpointsForKubeEndpoints() returns nil for endpoints with only NotReadyAddresses, but envoy.NewCluster() creates invalid clusters with this nil value.

Fix: Skip snapshot updates when endpoints exist but aren't ready. The tracker already watches Endpoints and will trigger reconciliation when they become ready.

This prevents invalid Envoy configs and "unknown weighted cluster" errors.

# Changes


- :bug: Fix handling of endpoints with no ready addresses

/kind bug
Fixes #1396

<!-- Please include the 'why' behind your changes if no issue exists -->

# Release Note

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Fix handling of endpoints with no ready addresses
```
