### PR TITLE
Increase tolerance for tracing sampling rate test

### DIFF
--- a/test/tracing/tracing_test.go
+++ b/test/tracing/tracing_test.go
@@ -177,7 +177,7 @@ func TestTracingSamplingRate(t *testing.T) {
 			samplingRate:     "0.67",
 			numRequests:      30,
 			expectedTraces:   20,
-			tolerancePercent: 20,
+			tolerancePercent: 50,
 		},
 		{
 			name:           "sampling rate 1.0 (all traces)",


### PR DESCRIPTION
CI is flaky as sampling rate tolerance is not high enough, there are sometimes 13 or 25 instead of 20 +- 4 traces. If this is not reliable we might need to remove the test or increase request count (and sleep time) to reduce the relative deviation from the expected value.

Example pipeline with flaky runs: https://github.com/knative-extensions/net-kourier/actions/runs/19866492361/job/56930632037?pr=1360