### PR TITLE
Add IPv6 support for Kourier

### DIFF
--- a/config/200-bootstrap.yaml
+++ b/config/200-bootstrap.yaml
@@ -45,8 +45,9 @@ data:
         - name: stats_listener
           address:
             socket_address:
-              address: 0.0.0.0
+              address: "::"
               port_value: 9000
+              ipv4_compat: true
           filter_chains:
             - filters:
                 - name: envoy.filters.network.http_connection_manager

--- a/pkg/endpointslice/endpointslice.go
+++ b/pkg/endpointslice/endpointslice.go
@@ -21,14 +21,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-// ReadyAddressesFromSlice extracts ready IPv4 addresses from an EndpointSlice.
-// Returns nil if the slice is non-IPv4 or has no ready endpoints.
+// ReadyAddressesFromSlice extracts ready IP addresses from an EndpointSlice.
+// Returns nil if the slice uses FQDN addressing or has no ready endpoints.
 //
 // Future consideration: A more sophisticated implementation could check Serving and
 // Terminating conditions to support graceful draining during rolling updates, similar
 // to Istio, Traefik, and MetalLB implementations.
 func ReadyAddressesFromSlice(slice *discoveryv1.EndpointSlice) sets.Set[string] {
-	if slice.AddressType != discoveryv1.AddressTypeIPv4 {
+	if slice.AddressType != discoveryv1.AddressTypeIPv4 && slice.AddressType != discoveryv1.AddressTypeIPv6 {
 		return nil
 	}
 

--- a/pkg/endpointslice/endpointslice_test.go
+++ b/pkg/endpointslice/endpointslice_test.go
@@ -144,7 +144,7 @@ func TestReadyAddressesFromSlice(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "IPv6 slice returns nil",
+			name: "IPv6 with ready endpoints",
 			slice: &discoveryv1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-slice",
@@ -159,7 +159,7 @@ func TestReadyAddressesFromSlice(t *testing.T) {
 					},
 				},
 			},
-			want: nil,
+			want: []string{"2001:db8::1"},
 		},
 		{
 			name: "FQDN slice returns nil",

--- a/pkg/generator/endpointslice.go
+++ b/pkg/generator/endpointslice.go
@@ -28,9 +28,9 @@ import (
 
 // lbEndpointsForKubeEndpointSlices converts Kubernetes EndpointSlice resources
 // to Envoy LbEndpoints. It aggregates endpoints from multiple slices and filters
-// for IPv4 addressing mode and ready endpoints only.
+// for IP addressing mode and ready endpoints only.
 func lbEndpointsForKubeEndpointSlices(slices []*discoveryv1.EndpointSlice, targetPort int32) []*endpoint.LbEndpoint {
-	// Aggregate all ready IPv4 addresses from all slices
+	// Aggregate all ready addresses from all slices
 	allAddresses := sets.New[string]()
 	for _, slice := range slices {
 		addresses := endpointslice.ReadyAddressesFromSlice(slice)

--- a/pkg/generator/endpointslice_test.go
+++ b/pkg/generator/endpointslice_test.go
@@ -157,7 +157,7 @@ func TestLbEndpointsForKubeEndpointSlices(t *testing.T) {
 			want:       1,
 		},
 		{
-			name: "filter IPv6 and FQDN addressing",
+			name: "include IPv4 and IPv6, filter FQDN",
 			slices: []*discoveryv1.EndpointSlice{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -205,9 +205,32 @@ func TestLbEndpointsForKubeEndpointSlices(t *testing.T) {
 						},
 					},
 				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-svc-fqdn",
+						Namespace: "default",
+						Labels: map[string]string{
+							discoveryv1.LabelServiceName: "test-svc",
+						},
+					},
+					AddressType: discoveryv1.AddressTypeFQDN,
+					Endpoints: []discoveryv1.Endpoint{
+						{
+							Addresses: []string{"example.com"},
+							Conditions: discoveryv1.EndpointConditions{
+								Ready: ptr.To(true),
+							},
+						},
+					},
+					Ports: []discoveryv1.EndpointPort{
+						{
+							Port: ptr.To(int32(8080)),
+						},
+					},
+				},
 			},
 			targetPort: 8080,
-			want:       1, // only IPv4
+			want:       2, // IPv4 + IPv6 included, FQDN filtered
 		},
 		{
 			name:       "empty slices",

--- a/pkg/reconciler/ingress/config/ext_authz.go
+++ b/pkg/reconciler/ingress/config/ext_authz.go
@@ -19,6 +19,8 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net"
+	"strconv"
 	"time"
 
 	v3Cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -191,7 +193,7 @@ func externalAuthzFilter(conf *ExternalAuthzConfig) *hcm.HttpFilter {
 		extAuthConfig.Services = &extAuthService.ExtAuthz_HttpService{
 			HttpService: &extAuthService.HttpService{
 				ServerUri: &core.HttpUri{
-					Uri: fmt.Sprintf("%s://%s:%d", conf.Protocol, conf.Host, conf.Port),
+					Uri: fmt.Sprintf("%s://%s", conf.Protocol, net.JoinHostPort(conf.Host, strconv.FormatUint(uint64(conf.Port), 10))),
 					HttpUpstreamType: &core.HttpUri_Cluster{
 						Cluster: extAuthzClusterName,
 					},

--- a/pkg/reconciler/ingress/config/ext_authz_test.go
+++ b/pkg/reconciler/ingress/config/ext_authz_test.go
@@ -304,6 +304,39 @@ func Test_externalAuthZFilter_extAuthz(t *testing.T) {
 			},
 		},
 	}, {
+		name: "http with IPv6 host",
+		conf: &ExternalAuthzConfig{
+			Host:            "2001:db8::1",
+			Port:            8080,
+			MaxRequestBytes: 8192,
+			Timeout:         2000,
+			Protocol:        "http",
+		},
+		extAuthzWanted: &extAuthService.ExtAuthz{
+			TransportApiVersion: core.ApiVersion_V3,
+			WithRequestBody: &extAuthService.BufferSettings{
+				MaxRequestBytes:     8192,
+				AllowPartialMessage: true,
+			},
+			Services: &extAuthService.ExtAuthz_HttpService{
+				HttpService: &extAuthService.HttpService{
+					ServerUri: &core.HttpUri{
+						Uri: "http://[2001:db8::1]:8080",
+						HttpUpstreamType: &core.HttpUri_Cluster{
+							Cluster: extAuthzClusterName,
+						},
+						Timeout: durationpb.New(time.Duration(2000) * time.Millisecond),
+					},
+					AuthorizationRequest: &extAuthService.AuthorizationRequest{
+						HeadersToAdd: []*core.HeaderValue{{
+							Key:   "client",
+							Value: "kourier",
+						}},
+					},
+				},
+			},
+		},
+	}, {
 		name: "https with path prefix",
 		conf: &ExternalAuthzConfig{
 			Host:            "example.com",

--- a/pkg/reconciler/ingress/lister.go
+++ b/pkg/reconciler/ingress/lister.go
@@ -55,7 +55,7 @@ func (l *gatewayPodTargetLister) ListProbeTargets(_ context.Context, ing *v1alph
 		return nil, fmt.Errorf("failed to list endpointslices for internal service: %w", err)
 	}
 
-	// Aggregate ready IPv4 addresses from all slices
+	// Aggregate ready addresses from all slices
 	allAddresses := sets.New[string]()
 	for _, slice := range slices {
 		addresses := endpointslice.ReadyAddressesFromSlice(slice)


### PR DESCRIPTION
Kourier failed on IPv6-only clusters: the EndpointSlice watcher filtered out IPv6 addresses so the controller couldn't discover gateway pods, the bootstrap stats listener bound to IPv4 only, and the extauthz URI construction didn't bracket IPv6 addresses.

Using an IPv6 address with `ipv4_compat` works in IPv4 only environments as I tested locally, CI should confirm that.

Related to https://github.com/knative/serving/pull/16591

## Changes
- Accept IPv6 EndpointSlices in ReadyAddressesFromSlice
- Bind bootstrap stats listener to :: with ipv4_compat for dual-stack
- Use net.JoinHostPort in extauthz URI for correct IPv6 bracketing


/kind enhancement

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Add IPv6-only cluster support for Kourier. EndpointSlice discovery now includes IPv6 addresses, the stats listener binds dual-stack, and extauthz URIs correctly bracket IPv6 hosts. Configure with listen-ip-addresses: "::" in config-kourier.
```

