### PR TITLE
use controller's context in xds_server

### DIFF
--- a/pkg/envoy/server/xds_server.go
+++ b/pkg/envoy/server/xds_server.go
@@ -44,8 +44,7 @@ type XdsServer struct {
 	snapshotCache  cache.SnapshotCache
 }
 
-func NewXdsServer(managementPort uint, callbacks xds.Callbacks) *XdsServer {
-	ctx := context.Background()
+func NewXdsServer(ctx context.Context, managementPort uint, callbacks xds.Callbacks) *XdsServer {
 	snapshotCache := cache.NewSnapshotCache(true, cache.IDHash{}, nil)
 	srv := xds.NewServer(ctx, snapshotCache, callbacks)
 

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -129,6 +129,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	}
 
 	envoyXdsServer := envoy.NewXdsServer(
+		ctx,
 		managementPort,
 		&xds.CallbackFuncs{
 			StreamRequestFunc: func(_ int64, req *v3.DiscoveryRequest) error {

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -163,7 +163,7 @@ func TestReconcile(t *testing.T) {
 		c, _ := generator.NewCaches(ctx, kubeclient)
 
 		r := &Reconciler{
-			xdsServer:         server.NewXdsServer(18000, &xds.CallbackFuncs{}),
+			xdsServer:         server.NewXdsServer(ctx, 18000, &xds.CallbackFuncs{}),
 			caches:            c,
 			ingressTranslator: &it,
 			resyncConflicts:   func() {},


### PR DESCRIPTION
# Changes
- :broom: Pass controller's context to XdsServer

so that the `grpcServer.GracefulStop()` is actually invoked (as otherwise there is nothing that would cancel the currently used `context.Background()` context)
